### PR TITLE
Add kotlinCompilerPluginClasspath to default configurations

### DIFF
--- a/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
+++ b/slack-plugin/src/main/kotlin/slack/gradle/avoidance/ComputeAffectedProjectsTask.kt
@@ -202,6 +202,7 @@ public abstract class ComputeAffectedProjectsTask : DefaultTask(), DiagnosticWri
         "debugImplementation",
         "implementation",
         "kapt",
+        "kotlinCompilerPluginClasspath",
         "ksp",
         "releaseApi",
         "releaseImplementation",


### PR DESCRIPTION
This is where compiler plugins live

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/slack-gradle-plugin/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->