### PR TITLE
Clean up aliases

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/Aliases.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/Aliases.kt
@@ -42,79 +42,40 @@ import org.gradle.api.Project
  * }
  * ```
  */
-public fun Project.foundry(body: FoundryExtension.() -> Unit) {
-  extensions.findByType<FoundryExtension>()?.let(body) ?: error("Foundry extension not found.")
+public fun Project.foundry(action: Action<FoundryExtension>) {
+  extensions.findByType<FoundryExtension>()?.let(action::execute)
+    ?: error("Foundry extension not found.")
 }
 
-@Deprecated("Use foundry", ReplaceWith("foundry(body)"), level = DeprecationLevel.ERROR)
-public fun Project.slack(body: FoundryExtension.() -> Unit) {
-  extensions.findByType<FoundryExtension>()?.let(body) ?: error("Foundry extension not found.")
-}
-
-/**
- * Common entry point for configuring slack-android-specific bits of projects.
- *
- * ```
- * foundryAndroid {
- *   library {
- *     // ...
- *   }
- * }
- * ```
- */
-public fun Project.foundryAndroid(action: Action<AndroidHandler>) {
-  foundry { android(action) }
+@Deprecated("Use foundry", ReplaceWith("foundry(action)"), level = DeprecationLevel.WARNING)
+public fun Project.slack(action: Action<FoundryExtension>) {
+  extensions.findByType<FoundryExtension>()?.let(action::execute)
+    ?: error("Foundry extension not found.")
 }
 
 @Deprecated(
   "Use foundryAndroid",
-  ReplaceWith("foundryAndroid(body)"),
-  level = DeprecationLevel.ERROR,
+  ReplaceWith("foundry { android(action) }"),
+  level = DeprecationLevel.WARNING,
 )
 public fun Project.slackAndroid(action: Action<AndroidHandler>) {
-  foundryAndroid(action)
-}
-
-/**
- * Common entry point for configuring slack-android-library-specific bits of projects.
- *
- * ```
- * androidLibrary {
- *   // ...
- * }
- * ```
- */
-public fun Project.foundryAndroidLibrary(action: Action<SlackAndroidLibraryExtension>) {
-  foundry { android { library(action) } }
+  foundry { android(action) }
 }
 
 @Deprecated(
   "Use foundryAndroidLibrary",
-  ReplaceWith("foundryAndroidLibrary(body)"),
-  level = DeprecationLevel.ERROR,
+  ReplaceWith("foundry { android { library(action) } }"),
+  level = DeprecationLevel.WARNING,
 )
 public fun Project.slackAndroidLibrary(action: Action<SlackAndroidLibraryExtension>) {
-  foundryAndroidLibrary(action)
-}
-
-/**
- * Common entry point for configuring slack-android-library-specific bits of projects.
- *
- * ```
- * androidApp {
- *   // ...
- * }
- * ```
- */
-public fun Project.foundryAndroidApp(action: Action<SlackAndroidAppExtension>) {
-  foundry { android { app(action) } }
+  foundry { android { library(action) } }
 }
 
 @Deprecated(
-  "Use foundryAndroidApp",
-  ReplaceWith("foundryAndroidApp(body)"),
-  level = DeprecationLevel.ERROR,
+  "Use foundry",
+  ReplaceWith("foundry { android { app(action) } }"),
+  level = DeprecationLevel.WARNING,
 )
 public fun Project.slackAndroidApp(action: Action<SlackAndroidAppExtension>) {
-  foundryAndroidApp(action)
+  foundry { android { app(action) } }
 }


### PR DESCRIPTION
This removes the nested old alias extensions in favor of running things just through `foundry {}`. This also fixes some deprecation levels to be warning instead of error, as the latter would fail gradle sync unfortunately

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->