### PR TITLE
Provide default for kapt language version

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/kgp/KgpTasks.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/kgp/KgpTasks.kt
@@ -153,9 +153,9 @@ internal object KgpTasks {
       project.tasks.withType(KaptGenerateStubsTask::class.java).configureEach {
         compilerOptions {
           val zipped =
-            foundryProperties.kotlinProgressive.zip(foundryProperties.kaptLanguageVersion) {
-              progressive,
-              kaptLanguageVersion ->
+            foundryProperties.kotlinProgressive.zip(
+              foundryProperties.kaptLanguageVersion.orElse(KotlinVersion.DEFAULT)
+            ) { progressive, kaptLanguageVersion ->
               if (kaptLanguageVersion != KotlinVersion.DEFAULT) {
                 false
               } else {


### PR DESCRIPTION
Otherwise the zip() operator will never compute

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->