### PR TITLE
Track deleted build files when computing parent projects in Skippy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We've restructured this project! Since its early days as a simple Gradle convent
 ### Misc
 
 - **Fix**: Gracefully handle undefined kapt language versions when computing `progressive`.
+- **Fix**: Track deleted build files when computing parent projects in Skippy.
 - Update Clikt to `5.0.1`.
 - Update oshi-core to `6.6.5`.
 - Build against DAGP 2.x.


### PR DESCRIPTION
In this case we "know" it's attached to that project, even if that project no longer exists.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->