### PR TITLE
Disable AI Chat Window for New Skate Release

### DIFF
--- a/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
+++ b/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
@@ -22,8 +22,8 @@
                            implementationClass="foundry.intellij.skate.featureflags.FeatureFlagAnnotator"/>
         <projectIndexingActivityHistoryListener implementation="foundry.intellij.skate.idemetrics.IndexingListener"/>
         <postStartupActivity implementation="foundry.intellij.skate.PostStartupActivityExtension"/>
-        <toolWindow factoryClass="foundry.intellij.skate.aibot.ChatBotToolWindow" id="DevXPAI" anchor="right"
-                    canCloseContents="true" secondary="false" icon="AllIcons.Actions.Lightning"/>
+<!--        <toolWindow factoryClass="foundry.intellij.skate.aibot.ChatBotToolWindow" id="DevXPAI" anchor="right"-->
+<!--                    canCloseContents="true" secondary="false" icon="AllIcons.Actions.Lightning"/>-->
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">


### PR DESCRIPTION
Just commented out the tool window for now because it's not ready yet. So we can do a new Skate release that's compatible with K2.
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->