### PR TITLE
Improve Skate publishing

### DIFF
--- a/platforms/intellij/skate/change-notes.html
+++ b/platforms/intellij/skate/change-notes.html
@@ -1,5 +1,10 @@
 <![CDATA[
 
+<h2>Unreleased</h2>
+<ul>
+    <li>Improved release process so hopefully more changelog notes appear now :)</li>
+</ul>
+
 <h2>0.8.0</h2>
 <ul>
     <li>Support K2 with Skate</li>

--- a/publish_skate.sh
+++ b/publish_skate.sh
@@ -1,3 +1,59 @@
 #!/usr/bin/env bash
 
+source tools/scripts/scriptUtil.sh
+
+changeNotes=platforms/intellij/skate/change-notes.html
+# Default values
+specific_version=""
+increment_type=""
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --major|--minor|--patch)
+            increment_type="${1/--/}"  # Remove -- prefix
+            ;;
+        *)
+            specific_version="$1"  # Assume it's a specific version
+            ;;
+    esac
+    shift
+done
+
+# Fetch the latest version from the changelog if no specific version provided
+if [[ -z "$specific_version" ]]; then
+    latest_version=$(awk '/<h2>[0-9]+\.[0-9]+\.[0-9]+<\/h2>/ {
+        gsub(/<\/?h2>/, "", $0);  # Remove <h2> tags
+        print $0;
+        exit;
+    }' $changeNotes)
+    version=$(increment_version "$latest_version" "$increment_type")
+else
+    version="$specific_version"
+fi
+
+# Export the new version for Gradle's version name
+export ORG_GRADLE_PROJECT_VERSION_NAME=$version
+
+# Update change-notes.xml
+# Use inline editing with compatibility for both macOS and Linux
+awk -v version="$version" '
+    /<h2>Unreleased<\/h2>/ {
+        print;
+        getline;  # Move to the next line containing <ul>...</ul>
+        print "<ul>\n</ul>";
+        print "\n<h2>" version "</h2>";
+        print $0;  # Print the original <ul> line, maintaining content
+        next;
+    }
+    { print }
+' $changeNotes > tmpfile && mv tmpfile $changeNotes
+
 ./gradlew :platforms:intellij:skate:uploadPluginToArtifactory --no-configuration-cache --stacktrace
+
+# Prepare release
+git commit -am "Prepare for Skate release $ORG_GRADLE_PROJECT_VERSION_NAME."
+git tag -a "skate-$ORG_GRADLE_PROJECT_VERSION_NAME" -m "Skate Version $ORG_GRADLE_PROJECT_VERSION_NAME"
+
+# Push it all up
+git push && git push --tags

--- a/publish_skate.sh
+++ b/publish_skate.sh
@@ -52,8 +52,10 @@ awk -v version="$version" '
 ./gradlew :platforms:intellij:skate:uploadPluginToArtifactory --no-configuration-cache --stacktrace
 
 # Prepare release
+git config user.name "OSS-Bot"
+git config user.email "svc-oss-bot@slack-corp.com"
 git commit -am "Prepare for Skate release $ORG_GRADLE_PROJECT_VERSION_NAME."
-git tag -a "skate-$ORG_GRADLE_PROJECT_VERSION_NAME" -m "Skate Version $ORG_GRADLE_PROJECT_VERSION_NAME"
+git tag -a "skate-$ORG_GRADLE_PROJECT_VERSION_NAME" -m "skate-$ORG_GRADLE_PROJECT_VERSION_NAME"
 
 # Push it all up
 git push && git push --tags

--- a/release.sh
+++ b/release.sh
@@ -2,11 +2,7 @@
 
 set -exo pipefail
 
-# Gets a property out of a .properties file
-# usage: getProperty $key $filename
-function getProperty() {
-    grep "${1}" "$2" | cut -d'=' -f2
-}
+source tools/scripts/scriptUtil.sh
 
 NEW_VERSION=$1
 SNAPSHOT_VERSION=$(getProperty 'VERSION_NAME' gradle.properties)

--- a/tools/scripts/scriptUtil.sh
+++ b/tools/scripts/scriptUtil.sh
@@ -1,0 +1,21 @@
+# Source this file to use its functions
+
+# Gets a property out of a .properties file
+# usage: getProperty $key $filename
+function getProperty() {
+  grep "${1}" "$2" | cut -d'=' -f2
+}
+
+# Increments an input version string given a version type
+# usage: increment_version $current_version $version_type
+increment_version() {
+    local current_version=$1
+    local version_type=$2
+    IFS='.' read -r major minor patch <<< "$current_version"
+    case "$version_type" in
+        major) ((major++)); minor=0; patch=0 ;;
+        minor) ((minor++)); patch=0 ;;
+        patch) ((patch++)) ;;
+    esac
+    echo "$major.$minor.$patch"
+}


### PR DESCRIPTION
Now we get tags and automatic changelog management. This tunes the publish command to now take either a specific version or an automatic version via `--major/--minor/--patch` argument.

`./publish_skate --major` or `./publish_skate 0.8.1`.

We should now start adding to the "Unreleased" section when we make changes, similar to what we do with the top-level CHANGELOG.md for foundry changes.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->