### PR TITLE
Don't depend on build sources in mod score if `MODULE_SCORE_INCLUDE_GENERATED` is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+* **Fix**: Don't depend on build sources in mod score if `MODULE_SCORE_INCLUDE_GENERATED` is false
+
 0.21.0
 ------
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
@@ -162,8 +162,10 @@ public object ModuleStatsTasks {
 
     val generatedSourcesAdded = AtomicBoolean()
     val addGeneratedSources = {
-      if (locTask != null && generatedSourcesAdded.compareAndSet(false, true)) {
-        locTask.configure {
+      val shouldConfigure =
+        locTask != null && generatedSourcesAdded.compareAndSet(false, true) && includeGenerated
+      if (shouldConfigure) {
+        locTask!!.configure {
           generatedSrcsDir.setDisallowChanges(project.layout.buildDirectory.dir("generated"))
         }
       }


### PR DESCRIPTION
Otherwise this would fail to execute because the dir doesn't exist

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->