### PR TITLE
Initial pass at ModuleTopographyTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+- [gradle] Introduce new `moduleTopography` task. This is a general task that attempts to validate project configurations by looking for features that are enabled but unused. Currently covers a few core features like kapt, ksp, moshi code gen, dagger/anvil, and viewbinding. Outputs are printed and written to a JSON file. Add `--validate-all` to make the tasks fail on validation issues.
+- [gradle] Cache global `FoundryProperties` instance for subproject use.
+- [cli] Check for non-existent paths before traversing in `Path.walkEachFile()`.
+
 0.21.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 - [gradle] Introduce new `moduleTopography` task. This is a general task that attempts to validate project configurations by looking for features that are enabled but unused. Currently covers a few core features like kapt, ksp, moshi code gen, dagger/anvil, and viewbinding. Outputs are printed and written to a JSON file. Add `--validate-all` to make the tasks fail on validation issues.
 - [gradle] Cache global `FoundryProperties` instance for subproject use.
+- [gradle] Add `composeRuntimeOnly()` DSL feature.
 - [cli] Check for non-existent paths before traversing in `Path.walkEachFile()`.
 
 0.21.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ kotlinPoet = "1.18.1"
 ktfmt = "0.52"
 markdown = "0.26.0"
 mavenPublish = "0.30.0"
+mordant = "3.0.0"
 moshi = "1.15.1"
 moshix = "0.28.0"
 nullawayGradle = "2.1.0"
@@ -130,6 +131,9 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 junit = "junit:junit:4.13.2"
 markdown = "org.jetbrains:markdown:0.7.3"
+mordant = { module = "com.github.ajalt.mordant:mordant", version.ref = "mordant" }
+mordant-coroutines = { module = "com.github.ajalt.mordant:mordant-coroutines", version.ref = "mordant" }
+mordant-markdown = { module = "com.github.ajalt.mordant:mordant-markdown", version.ref = "mordant" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-rc-1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/platforms/gradle/foundry-gradle-plugin/build.gradle.kts
+++ b/platforms/gradle/foundry-gradle-plugin/build.gradle.kts
@@ -88,6 +88,9 @@ dependencies {
   implementation(libs.jgrapht)
   implementation(libs.jna)
   implementation(libs.jna.platform)
+  implementation(libs.mordant)
+  implementation(libs.mordant.coroutines)
+  implementation(libs.mordant.markdown)
   implementation(libs.moshi)
   implementation(libs.oshi) { because("To read hardware information") }
   implementation(libs.rxjava)

--- a/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
+++ b/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
@@ -1,5 +1,148 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.1)" variant="all" version="8.8.0-alpha01">
+<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.8.0-alpha01">
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="  val segmentName = this::class.simpleName!!"
+        errorLine2="                                          ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/dependencies/DependencyCollection.kt"
+            line="111"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    gradleProperty ?: this::class.simpleName!!.lowercase(Locale.US)"
+        errorLine2="                                            ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/dependencies/DependencyGroup.kt"
+            line="43"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="                    var newConfiguration = advice.toConfiguration!!"
+        errorLine2="                                                                 ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
+            line="231"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="              val oldConfiguration = abiDep.fromConfiguration!!"
+        errorLine2="                                                             ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
+            line="300"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="              var newConfiguration = abiDep.toConfiguration!!"
+        errorLine2="                                                           ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
+            line="301"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true"
+        errorLine2="                    ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/FoundryExtension.kt"
+            line="1142"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    optionalStringProperty(key, defaultValue)!!"
+        errorLine2="                                             ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/FoundryProperties.kt"
+            line="59"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="      statsFiles.map { it.source().buffer().use(adapter::fromJson)!! }.sortedBy { it.modulePath }"
+        errorLine2="                                                                  ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/stats/ModuleStats.kt"
+            line="314"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="          JsonTools.MOSHI.adapter&lt;LocTask.LocData>().fromJson(it)!!"
+        errorLine2="                                                                 ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/stats/ModuleStats.kt"
+            line="411"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="      }!!"
+        errorLine2="       ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt"
+            line="232"
+            column="8"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="        path.source().buffer().use { JsonTools.MOSHI.adapter&lt;VersionsOutput>().fromJson(it)!! }"
+        errorLine2="                                                                                           ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/Platforms.kt"
+            line="173"
+            column="92"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="      Publisher.interProjectPublisher(project, artifact.objectInstance!!)"
+        errorLine2="                                                                      ~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt"
+            line="127"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="MoshiUsageNonMoshiClassPlatform"
+        message="Platform type &apos;Regex&apos; is not natively supported by Moshi."
+        errorLine1="  val removalPatterns: Set&lt;Regex>?,"
+        errorLine2="                       ~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/topography/models.kt"
+            line="34"
+            column="24"/>
+    </issue>
 
     <issue
         id="GradleProjectIsolation"
@@ -85,7 +228,7 @@
         errorLine2="                ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryProperties.kt"
-            line="175"
+            line="184"
             column="17"/>
     </issue>
 
@@ -96,7 +239,7 @@
         errorLine2="                               ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryRootPlugin.kt"
-            line="69"
+            line="67"
             column="32"/>
     </issue>
 
@@ -107,7 +250,7 @@
         errorLine2="             ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryRootPlugin.kt"
-            line="489"
+            line="441"
             column="14"/>
     </issue>
 
@@ -118,7 +261,7 @@
         errorLine2="                               ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/GlobalConfig.kt"
-            line="32"
+            line="33"
             column="32"/>
     </issue>
 
@@ -290,6 +433,17 @@
     <issue
         id="InternalAgpApiUsage"
         message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalAgpApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
         errorLine1="import com.android.build.gradle.internal.dsl.BaseAppModuleExtension"
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -356,11 +510,22 @@
     <issue
         id="InternalGradleApiUsage"
         message="Avoid using internal Gradle APIs"
+        errorLine1="import org.gradle.api.internal.plugins.PluginRegistry"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt"
+            line="47"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalGradleApiUsage"
+        message="Avoid using internal Gradle APIs"
         errorLine1="import org.gradle.api.internal.provider.MissingValueException"
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/Platforms.kt"
-            line="33"
+            line="32"
             column="1"/>
     </issue>
 
@@ -404,7 +569,7 @@
         errorLine2="        ~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt"
-            line="270"
+            line="257"
             column="9"/>
     </issue>
 
@@ -415,7 +580,7 @@
         errorLine2="                                                    ~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/Platforms.kt"
-            line="269"
+            line="187"
             column="53"/>
     </issue>
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
@@ -20,6 +20,7 @@ import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
 import com.diffplug.spotless.LineEnding
 import foundry.gradle.develocity.NoOpBuildScanAdapter
 import foundry.gradle.develocity.findAdapter
+import foundry.gradle.model.ModuleTopographyTask
 import foundry.gradle.stats.ModuleStatsTasks
 import java.util.Locale
 import java.util.Optional
@@ -55,7 +56,16 @@ internal class FoundryBasePlugin @Inject constructor(private val buildFeatures: 
       val versionCatalog =
         target.getVersionsCatalogOrNull() ?: error("SGP requires use of version catalogs!")
       val foundryTools = target.foundryTools()
-      StandardProjectConfigurations(foundryProperties, versionCatalog, foundryTools).applyTo(target)
+      val foundryExtension =
+        target.extensions.create(
+          "foundry",
+          FoundryExtension::class.java,
+          foundryProperties,
+          target,
+          versionCatalog,
+        )
+      StandardProjectConfigurations(foundryProperties, versionCatalog, foundryTools)
+        .applyTo(target, foundryExtension, foundryProperties)
 
       // Configure Gradle's test-retry plugin for insights on build scans on CI only
       // Thinking here is that we don't want them to retry when iterating since failure
@@ -83,6 +93,7 @@ internal class FoundryBasePlugin @Inject constructor(private val buildFeatures: 
       }
 
       ModuleStatsTasks.configureSubproject(target, foundryProperties)
+      ModuleTopographyTask.register(target, foundryExtension)
     }
 
     // Everything in here applies to all projects

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
@@ -20,8 +20,8 @@ import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
 import com.diffplug.spotless.LineEnding
 import foundry.gradle.develocity.NoOpBuildScanAdapter
 import foundry.gradle.develocity.findAdapter
-import foundry.gradle.model.ModuleTopographyTask
 import foundry.gradle.stats.ModuleStatsTasks
+import foundry.gradle.topography.ModuleTopographyTask
 import java.util.Locale
 import java.util.Optional
 import javax.inject.Inject

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
@@ -95,7 +95,7 @@ internal class FoundryBasePlugin @Inject constructor(private val buildFeatures: 
       }
 
       ModuleStatsTasks.configureSubproject(target, foundryProperties)
-      ModuleTopographyTask.register(target, foundryExtension)
+      ModuleTopographyTask.register(target, foundryExtension, foundryProperties)
     }
 
     // Everything in here applies to all projects

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -864,7 +864,7 @@ constructor(
       versionCatalog.findBundle(alias).orElse(null)
     }
   internal val enabled = objects.property<Boolean>().convention(false)
-  internal val enableCompiler = objects.property<Boolean>().convention(true)
+  internal val enableCompiler = objects.property<Boolean>().convention(false)
   internal val multiplatform = objects.property<Boolean>().convention(false)
 
   private val compilerOptions: ListProperty<String> =

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -1098,6 +1098,8 @@ public abstract class AndroidFeaturesHandler @Inject constructor() {
     this.androidExtension = androidExtension
   }
 
+  internal fun viewBindingEnabled() = androidExtension?.buildFeatures?.viewBinding ?: false
+
   /**
    * Enables android instrumentation tests for this project.
    *

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -864,7 +864,7 @@ constructor(
       versionCatalog.findBundle(alias).orElse(null)
     }
   internal val enabled = objects.property<Boolean>().convention(false)
-  internal val enableCompiler = objects.property<Boolean>().convention(false)
+  internal val enableCompiler = objects.property<Boolean>().convention(true)
   internal val multiplatform = objects.property<Boolean>().convention(false)
 
   private val compilerOptions: ListProperty<String> =

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
@@ -737,6 +737,10 @@ internal constructor(
   public val kotlinProgressive: Provider<Boolean>
     get() = resolver.booleanProvider("foundry.kotlin.progressive", defaultValue = true)
 
+  /** Property to enable auto-fixing in topography validation. */
+  public val topographyAutoFix: Provider<Boolean>
+    get() = resolver.booleanProvider("foundry.topography.validation.autoFix", defaultValue = false)
+
   internal fun requireAndroidSdkProperties(): AndroidSdkProperties {
     val compileSdk = compileSdkVersion ?: error("foundry.android.compileSdkVersion not set")
     val minSdk = minSdkVersion?.toInt() ?: error("foundry.android.minSdkVersion not set")

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/GlobalConfig.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/GlobalConfig.kt
@@ -21,6 +21,7 @@ import org.gradle.jvm.toolchain.JvmVendorSpec
 /** Registry of global configuration info. */
 public class GlobalConfig
 private constructor(
+  internal val globalFoundryProperties: FoundryProperties,
   internal val kotlinDaemonArgs: List<String>?,
   internal val errorProneCheckNamesAsErrors: List<String>,
   internal val affectedProjects: Set<String>?,
@@ -32,6 +33,7 @@ private constructor(
       check(project == project.rootProject) { "Project is not root project!" }
       val globalFoundryProperties = FoundryProperties(project)
       return GlobalConfig(
+        globalFoundryProperties = globalFoundryProperties,
         kotlinDaemonArgs = globalFoundryProperties.kotlinDaemonArgs,
         errorProneCheckNamesAsErrors =
           globalFoundryProperties.errorProneCheckNamesAsErrors?.split(":").orEmpty(),

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -92,17 +92,11 @@ internal class StandardProjectConfigurations(
   private val versionCatalog: VersionCatalog,
   private val foundryTools: FoundryTools,
 ) {
-  fun applyTo(project: Project) {
-    val foundryProperties = FoundryProperties(project)
-    val foundryExtension =
-      project.extensions.create(
-        "foundry",
-        FoundryExtension::class.java,
-        globalProperties,
-        foundryProperties,
-        project,
-        versionCatalog,
-      )
+  fun applyTo(
+    project: Project,
+    foundryExtension: FoundryExtension,
+    foundryProperties: FoundryProperties,
+  ) {
     if (foundryProperties.eagerlyConfigureArtifactPublishing) {
       setUpSubprojectArtifactPublishing(project)
     }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foundry.gradle.model
 
 import com.squareup.moshi.JsonClass
@@ -168,7 +183,7 @@ public abstract class ModuleTopographyTask : DefaultTask() {
       logger.error(
         """
           ${featuresToRemove.joinToString("\n"){ "- ${it.removalMessage}" }}
-          
+
           Validation errors written to ${featuresToRemoveOutputFile.asFile.get().absolutePath}
         """
           .trimIndent()
@@ -188,9 +203,9 @@ public abstract class ModuleTopographyTask : DefaultTask() {
       error(
         """
           Validation failed for the following features:
-          
+
           ${featuresToValidate.joinToString("\n", transform = ModuleFeature::removalMessage)}
-          
+
           Full list written to ${featuresToRemoveOutputFile.asFile.get().absolutePath}
         """
           .trimIndent()

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
@@ -1,0 +1,345 @@
+package foundry.gradle.model
+
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.adapter
+import foundry.cli.walkEachFile
+import foundry.gradle.FoundryExtension
+import foundry.gradle.properties.setDisallowChanges
+import foundry.gradle.register
+import foundry.gradle.util.JsonTools.MOSHI
+import java.nio.file.Path
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.extension
+import kotlin.io.path.useLines
+import okio.buffer
+import okio.sink
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+@CacheableTask
+public abstract class ModuleTopographyTask : DefaultTask() {
+  @get:Input public abstract val projectName: Property<String>
+
+  @get:Input public abstract val projectPath: Property<String>
+
+  @get:InputDirectory
+  @get:SkipWhenEmpty
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  public abstract val srcsDirProperty: DirectoryProperty
+
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  public abstract val buildDirProperty: DirectoryProperty
+
+  @get:Input @get:Optional public abstract val moshiCodeGenEnabled: Property<Boolean>
+  @get:Input @get:Optional public abstract val circuitCodeGenEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val daggerEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val daggerCompilerEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val viewBindingEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val composeEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val androidTestEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val kaptEnabled: Property<Boolean>
+
+  @get:Input @get:Optional public abstract val kspEnabled: Property<Boolean>
+
+  // TODO source DAGP files to check usage of Android APIs?
+
+  @get:OutputFile public abstract val topographyOutputFile: RegularFileProperty
+
+  @get:OutputFile public abstract val featuresToRemoveOutputFile: RegularFileProperty
+
+  init {
+    group = "foundry"
+  }
+
+  @OptIn(ExperimentalPathApi::class)
+  @TaskAction
+  public fun compute() {
+    val featuresEnabled = mutableSetOf<ModuleFeature>()
+    val featuresToRemove = mutableSetOf<ModuleFeature>()
+
+    val srcsDir = srcsDirProperty.asFile.get().toPath()
+
+    if (androidTestEnabled.getOrElse(false)) {
+      featuresEnabled += Features.AndroidTest
+      if (srcsDir.resolve("androidTest").walkEachFile().none()) {
+        featuresToRemove += Features.AndroidTest
+      }
+    }
+
+    val generatedSourcesDir = buildDirProperty.asFile.get().toPath().resolve("generated")
+
+    if (kspEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Ksp
+      if (generatedSourcesDir.resolve("ksp").walkEachFile().none()) {
+        featuresToRemove += Features.Ksp
+      }
+    }
+    if (kaptEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Kapt
+      if (generatedSourcesDir.resolve("source/kapt").walkEachFile().none()) {
+        featuresToRemove += Features.Kapt
+      }
+    }
+    if (viewBindingEnabled.getOrElse(false)) {
+      featuresEnabled += Features.ViewBinding
+      if (
+        generatedSourcesDir
+          .resolve("source/data_binding_base_class_source_out")
+          .walkEachFile()
+          .none()
+      ) {
+        featuresToRemove += Features.ViewBinding
+      }
+    }
+    if (daggerCompilerEnabled.getOrElse(false)) {
+      featuresEnabled += Features.DaggerCompiler
+      if (!Features.DaggerCompiler.hasAnnotationsUsedIn(srcsDir)) {
+        featuresToRemove += Features.DaggerCompiler
+      }
+      if (generatedSourcesDir.resolve("source/kapt").walkEachFile().none()) {
+        featuresToRemove += Features.DaggerCompiler
+      }
+    }
+
+    // TODO iterate over source files and check for matching annotations
+    if (composeEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Compose
+      if (!Features.Compose.hasAnnotationsUsedIn(srcsDir)) {
+        featuresToRemove += Features.Compose
+      }
+    }
+    if (daggerEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Dagger
+      if (!Features.Dagger.hasAnnotationsUsedIn(srcsDir)) {
+        featuresToRemove += Features.Dagger
+      }
+    }
+    if (moshiCodeGenEnabled.getOrElse(false)) {
+      featuresEnabled += Features.MoshiCodeGen
+      if (!Features.MoshiCodeGen.hasAnnotationsUsedIn(srcsDir)) {
+        featuresToRemove += Features.MoshiCodeGen
+      }
+    }
+    if (circuitCodeGenEnabled.getOrElse(false)) {
+      featuresEnabled += Features.CircuitInject
+      if (!Features.CircuitInject.hasAnnotationsUsedIn(srcsDir)) {
+        featuresToRemove += Features.CircuitInject
+      }
+    }
+
+    val topography =
+      ModuleTopography(
+        name = projectName.get(),
+        gradlePath = projectPath.get(),
+        features = featuresEnabled.toSortedSet(compareBy { it.name }),
+      )
+
+    JsonWriter.of(topographyOutputFile.asFile.get().sink().buffer()).use {
+      MOSHI.adapter<ModuleTopography>().toJson(it, topography)
+    }
+    JsonWriter.of(featuresToRemoveOutputFile.asFile.get().sink().buffer()).use {
+      MOSHI.adapter<Set<ModuleFeature>>()
+        .toJson(it, featuresToRemove.toSortedSet(compareBy { it.name }))
+    }
+  }
+
+  @OptIn(ExperimentalPathApi::class)
+  private fun ModuleFeature.hasAnnotationsUsedIn(srcsDir: Path): Boolean {
+    logger.debug("Checking for $name annotation usages in sources")
+    return srcsDir
+      .walkEachFile()
+      .run {
+        if (matchingAnnotationsExtensions.isNotEmpty()) {
+          filter { it.extension in Features.Compose.matchingAnnotationsExtensions }
+        } else {
+          this
+        }
+      }
+      .any { file ->
+        file.useLines { lines ->
+          for (line in lines) {
+            if (matchingAnnotations.any { it in line }) {
+              return@any true
+            }
+          }
+        }
+        false
+      }
+  }
+
+  internal companion object {
+    fun register(
+      project: Project,
+      foundryExtension: FoundryExtension,
+    ): TaskProvider<ModuleTopographyTask> {
+      val viewBindingEnabled =
+        project.provider { foundryExtension.androidHandler.featuresHandler.viewBindingEnabled() }
+      val task =
+        project.tasks.register<ModuleTopographyTask>("moduleTopography") {
+          srcsDirProperty.setDisallowChanges(project.layout.projectDirectory.dir("src"))
+          buildDirProperty.setDisallowChanges(project.layout.buildDirectory)
+          moshiCodeGenEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.moshiHandler.moshiCodegen
+          )
+          circuitCodeGenEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.circuitHandler.codegen
+          )
+          daggerEnabled.setDisallowChanges(foundryExtension.featuresHandler.daggerHandler.enabled)
+          daggerCompilerEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.daggerHandler.useDaggerCompiler
+          )
+          composeEnabled.setDisallowChanges(foundryExtension.featuresHandler.composeHandler.enabled)
+          androidTestEnabled.setDisallowChanges(
+            foundryExtension.androidHandler.featuresHandler.androidTest
+          )
+          this.viewBindingEnabled.setDisallowChanges(viewBindingEnabled)
+          topographyOutputFile.setDisallowChanges(
+            project.layout.buildDirectory.file("foundry/topography/topography.json")
+          )
+          featuresToRemoveOutputFile.setDisallowChanges(
+            project.layout.buildDirectory.file("foundry/topography/featuresToRemove.json")
+          )
+
+          // Depend on compilations
+          mustRunAfter(project.tasks.withType(JavaCompile::class.java))
+          mustRunAfter(project.tasks.withType(KotlinCompile::class.java))
+        }
+
+      project.pluginManager.withPlugin("dev.google.devtools.ksp") {
+        task.configure { kspEnabled.set(true) }
+      }
+      project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
+        task.configure { kaptEnabled.set(true) }
+      }
+      return task
+    }
+  }
+}
+
+@JsonClass(generateAdapter = true)
+public data class ModuleTopography(
+  val name: String,
+  val gradlePath: String,
+  val features: Set<ModuleFeature>,
+)
+
+@JsonClass(generateAdapter = true)
+public data class ModuleFeature(
+  val name: String,
+  val removalMessage: String?,
+  /** Generated sources root dir, if any. Note that descendants are checked */
+  val generatedSourcesDir: String? = null,
+  val generatedSourcesExtensions: Set<String> = emptySet(),
+  val matchingAnnotations: Set<String> = emptySet(),
+  val matchingAnnotationsExtensions: Set<String> = emptySet(),
+  /** If specified, looks for any sources in this dir */
+  val matchingSourcesDir: String? = null,
+)
+
+internal object Features {
+  internal val AndroidTest =
+    ModuleFeature(
+      name = "androidTest",
+      removalMessage = "Remove foundry.android.features.androidTest from your build file",
+      matchingSourcesDir = "src/androidTest",
+    )
+
+  internal val Compose =
+    ModuleFeature(
+      name = "compose",
+      removalMessage = "Remove foundry.features.compose from your build file",
+      matchingAnnotations = setOf("@Composable"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val Dagger =
+    ModuleFeature(
+      name = "dagger",
+      removalMessage = "Remove foundry.features.dagger from your build file",
+      matchingAnnotations =
+        setOf(
+          "@Inject",
+          "@AssistedInject",
+          "@ContributesTo",
+          "@ContributesBinding",
+          "@ContributesMultibinding",
+          "@Module",
+          "@Component",
+          "@Subcomponent",
+        ),
+      matchingAnnotationsExtensions = setOf("kt", "java"),
+    )
+
+  internal val DaggerCompiler =
+    ModuleFeature(
+      name = "dagger-compiler",
+      removalMessage = "Remove foundry.features.dagger.mergeComponents from your build file",
+      matchingAnnotations = setOf("@Component", "@Subcomponent"),
+      matchingAnnotationsExtensions = setOf("kt", "java"),
+      generatedSourcesDir = "build/generated/source/kapt",
+      generatedSourcesExtensions = setOf("java"),
+    )
+
+  internal val MoshiCodeGen =
+    ModuleFeature(
+      name = "moshi-codegen",
+      removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
+      matchingAnnotations = setOf("@JsonClass"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val CircuitInject =
+    ModuleFeature(
+      name = "circuit-inject",
+      removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
+      matchingAnnotations = setOf("@CircuitInject"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val Ksp =
+    ModuleFeature(
+      name = "ksp",
+      removalMessage = "Remove whatever is using KSP",
+      generatedSourcesDir = "build/generated/ksp",
+      // Don't specify extensions because KAPT can generate anything into resources
+    )
+
+  internal val Kapt =
+    ModuleFeature(
+      name = "kapt",
+      removalMessage = "Remove whatever is using KAPT",
+      generatedSourcesDir = "build/generated/source/kapt",
+      // Don't specify extensions because KSP can generate anything into resources
+    )
+
+  internal val ViewBinding =
+    ModuleFeature(
+      name = "viewbinding",
+      removalMessage = "Remove android.buildFeatures.viewBinding from your build file",
+      generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
+      generatedSourcesExtensions = setOf("java"),
+    )
+}

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/model/ModuleTopographyTask.kt
@@ -109,12 +109,7 @@ public abstract class ModuleTopographyTask : DefaultTask() {
     }
     if (viewBindingEnabled.getOrElse(false)) {
       featuresEnabled += Features.ViewBinding
-      if (
-        generatedSourcesDir
-          .resolve("source/data_binding_base_class_source_out")
-          .walkEachFile()
-          .none()
-      ) {
+      if (projectDir.resolve(Features.ViewBinding.generatedSourcesDir!!).walkEachFile().none()) {
         featuresToRemove += Features.ViewBinding
       }
     }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -178,7 +178,7 @@ public abstract class ModuleTopographyTask : DefaultTask() {
       return task
     }
 
-    fun registerValidationTask(
+    private fun registerValidationTask(
       project: Project,
       topographyTask: TaskProvider<ModuleTopographyTask>,
       foundryProperties: FoundryProperties,

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -190,6 +190,7 @@ public abstract class ModuleTopographyTask : DefaultTask() {
     ) {
       project.tasks.register<ValidateModuleTopographyTask>("validateModuleTopography") {
         topographyJson.set(topographyTask.flatMap { it.topographyOutputFile })
+        projectDirProperty.set(project.layout.projectDirectory)
         featuresToRemoveOutputFile.setDisallowChanges(
           project.layout.buildDirectory.file("foundry/topography/validate/featuresToRemove.json")
         )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -33,6 +33,7 @@ import kotlin.io.path.useLines
 import kotlin.jvm.optionals.getOrNull
 import okio.buffer
 import okio.sink
+import okio.source
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -41,9 +42,12 @@ import org.gradle.api.internal.plugins.PluginRegistry
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.options.Option
@@ -51,13 +55,10 @@ import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.internal.KaptTask
 import org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs
 
-@DisableCachingByDefault
 public abstract class ModuleTopographyTask : DefaultTask() {
   @get:Input public abstract val projectName: Property<String>
 
   @get:Input public abstract val projectPath: Property<String>
-
-  @get:Internal public abstract val projectDirProperty: DirectoryProperty
 
   @get:Input @get:Optional public abstract val moshiCodeGenEnabled: Property<Boolean>
 
@@ -77,6 +78,144 @@ public abstract class ModuleTopographyTask : DefaultTask() {
 
   @get:Input @get:Optional public abstract val pluginsProperty: SetProperty<String>
 
+  // TODO source DAGP files to check usage of Android APIs?
+
+  @get:OutputFile public abstract val topographyOutputFile: RegularFileProperty
+
+  init {
+    group = "foundry"
+  }
+
+  @TaskAction
+  public fun compute() {
+    val featuresEnabled = mutableSetOf<ModuleFeature>()
+
+    if (androidTestEnabled.getOrElse(false)) {
+      featuresEnabled += Features.AndroidTest
+    }
+
+    if (robolectricEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Robolectric
+    }
+
+    val plugins = pluginsProperty.getOrElse(emptySet())
+
+    if (viewBindingEnabled.getOrElse(false)) {
+      featuresEnabled += Features.ViewBinding
+    }
+    if (daggerCompilerEnabled.getOrElse(false)) {
+      featuresEnabled += Features.DaggerCompiler
+    }
+    if (composeEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Compose
+    }
+    if (daggerEnabled.getOrElse(false)) {
+      featuresEnabled += Features.Dagger
+    }
+    if (moshiCodeGenEnabled.getOrElse(false)) {
+      featuresEnabled += Features.MoshiCodeGen
+    }
+    if (circuitCodeGenEnabled.getOrElse(false)) {
+      featuresEnabled += Features.CircuitInject
+    }
+
+    val topography =
+      ModuleTopography(
+        name = projectName.get(),
+        gradlePath = projectPath.get(),
+        features = featuresEnabled.toSortedSet(compareBy { it.name }),
+        plugins = plugins.toSortedSet(),
+      )
+
+    JsonWriter.of(topographyOutputFile.asFile.get().sink().buffer()).use {
+      MOSHI.adapter<ModuleTopography>().toJson(it, topography)
+    }
+  }
+
+  internal companion object {
+    fun register(
+      project: Project,
+      foundryExtension: FoundryExtension,
+    ): TaskProvider<ModuleTopographyTask> {
+      val viewBindingEnabled =
+        project.provider { foundryExtension.androidHandler.featuresHandler.viewBindingEnabled() }
+      val task =
+        project.tasks.register<ModuleTopographyTask>("moduleTopography") {
+          projectName.set(project.name)
+          projectPath.set(project.path)
+          moshiCodeGenEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.moshiHandler.moshiCodegen
+          )
+          circuitCodeGenEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.circuitHandler.codegen
+          )
+          daggerEnabled.setDisallowChanges(foundryExtension.featuresHandler.daggerHandler.enabled)
+          daggerCompilerEnabled.setDisallowChanges(
+            foundryExtension.featuresHandler.daggerHandler.useDaggerCompiler
+          )
+          composeEnabled.setDisallowChanges(foundryExtension.featuresHandler.composeHandler.enabled)
+          androidTestEnabled.setDisallowChanges(
+            foundryExtension.androidHandler.featuresHandler.androidTest
+          )
+          robolectricEnabled.setDisallowChanges(
+            foundryExtension.androidHandler.featuresHandler.robolectric
+          )
+          this.viewBindingEnabled.setDisallowChanges(viewBindingEnabled)
+          topographyOutputFile.setDisallowChanges(
+            project.layout.buildDirectory.file("foundry/topography/model/topography.json")
+          )
+
+          // Depend on source-gen tasks
+
+          // Kapt
+          dependsOn(project.tasks.withType(KaptGenerateStubs::class.java))
+          dependsOn(project.tasks.withType(KaptTask::class.java))
+          // KSP
+          dependsOn(project.tasks.withType(KspTask::class.java))
+          dependsOn(project.tasks.withType(KspAATask::class.java))
+          // ViewBinding
+          dependsOn(project.tasks.withType(DataBindingGenBaseClassesTask::class.java))
+        }
+
+      // No easy way to query all plugin IDs, so we use an internal Gradle API
+      val pluginRegistry = project.serviceOf<PluginRegistry>()
+      project.plugins.configureEach {
+        val pluginType = this::class.java
+        val id = pluginRegistry.findPluginForClass(pluginType).getOrNull()?.id
+        if (id == null) {
+          project.logger.debug("Could not read plugin ID for type '$pluginType'")
+          return@configureEach
+        }
+        project.logger.debug("Reading plugin ID '$id' for type '$pluginType'")
+        project.pluginManager.withPlugin(id) { task.configure { pluginsProperty.add(id) } }
+      }
+
+      registerValidationTask(project, task)
+      return task
+    }
+
+    fun registerValidationTask(
+      project: Project,
+      topographyTask: TaskProvider<ModuleTopographyTask>,
+    ) {
+      project.tasks.register<ValidateModuleTopographyTask>("validateModuleTopography") {
+        topographyJson.set(topographyTask.flatMap { it.topographyOutputFile })
+        featuresToRemoveOutputFile.setDisallowChanges(
+          project.layout.buildDirectory.file("foundry/topography/validate/featuresToRemove.json")
+        )
+      }
+    }
+  }
+}
+
+@DisableCachingByDefault
+public abstract class ValidateModuleTopographyTask : DefaultTask() {
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.NONE)
+  public abstract val topographyJson: RegularFileProperty
+
+  @get:Internal public abstract val projectDirProperty: DirectoryProperty
+
   @get:Optional
   @get:Option(option = "validate-all", description = "Validates all")
   @get:Input
@@ -87,10 +226,6 @@ public abstract class ModuleTopographyTask : DefaultTask() {
   @get:Input
   public abstract val validate: Property<String>
 
-  // TODO source DAGP files to check usage of Android APIs?
-
-  @get:OutputFile public abstract val topographyOutputFile: RegularFileProperty
-
   @get:OutputFile public abstract val featuresToRemoveOutputFile: RegularFileProperty
 
   init {
@@ -100,21 +235,23 @@ public abstract class ModuleTopographyTask : DefaultTask() {
   @OptIn(ExperimentalPathApi::class)
   @TaskAction
   public fun compute() {
-    val featuresEnabled = mutableSetOf<ModuleFeature>()
+    val topography =
+      topographyJson.get().asFile.source().buffer().use {
+        MOSHI.adapter<ModuleTopography>().fromJson(it)
+      }!!
+    val features = topography.features
     val featuresToRemove = mutableSetOf<ModuleFeature>()
 
     val projectDir = projectDirProperty.asFile.get().toPath()
     val srcsDir = projectDir.resolve("src")
 
-    if (androidTestEnabled.getOrElse(false)) {
-      featuresEnabled += Features.AndroidTest
+    if (Features.AndroidTest in features) {
       if (srcsDir.resolve("androidTest").walkEachFile().none()) {
         featuresToRemove += Features.AndroidTest
       }
     }
 
-    if (robolectricEnabled.getOrElse(false)) {
-      featuresEnabled += Features.Robolectric
+    if (Features.Robolectric in features) {
       if (srcsDir.resolve("test").walkEachFile().none()) {
         featuresToRemove += Features.Robolectric
       }
@@ -123,31 +260,27 @@ public abstract class ModuleTopographyTask : DefaultTask() {
     val buildDir = projectDir.resolve("build")
     val generatedSourcesDir = buildDir.resolve("generated")
 
-    val plugins = pluginsProperty.getOrElse(emptySet())
+    val plugins = topography.plugins
     val kspEnabled = "dev.google.devtools.ksp" in plugins
     val kaptEnabled = "org.jetbrains.kotlin.kapt" in plugins
     val parcelizeEnabled = "org.jetbrains.kotlin.plugin.parcelize" in plugins
 
     if (kspEnabled) {
-      featuresEnabled += Features.Ksp
       if (generatedSourcesDir.resolve("ksp").walkEachFile().none()) {
         featuresToRemove += Features.Ksp
       }
     }
     if (kaptEnabled) {
-      featuresEnabled += Features.Kapt
       if (generatedSourcesDir.resolve("source/kapt").walkEachFile().none()) {
         featuresToRemove += Features.Kapt
       }
     }
-    if (viewBindingEnabled.getOrElse(false)) {
-      featuresEnabled += Features.ViewBinding
+    if (Features.ViewBinding in features) {
       if (projectDir.resolve(Features.ViewBinding.generatedSourcesDir!!).walkEachFile().none()) {
         featuresToRemove += Features.ViewBinding
       }
     }
-    if (daggerCompilerEnabled.getOrElse(false)) {
-      featuresEnabled += Features.DaggerCompiler
+    if (Features.DaggerCompiler in features) {
       if (!Features.DaggerCompiler.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.DaggerCompiler
       }
@@ -156,48 +289,32 @@ public abstract class ModuleTopographyTask : DefaultTask() {
       }
     }
 
-    // TODO iterate over source files and check for matching annotations
-    if (composeEnabled.getOrElse(false)) {
-      featuresEnabled += Features.Compose
+    if (Features.Compose in features) {
       if (!Features.Compose.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.Compose
       }
     }
-    if (daggerEnabled.getOrElse(false)) {
-      featuresEnabled += Features.Dagger
+    if (Features.Dagger in features) {
       if (!Features.Dagger.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.Dagger
       }
     }
-    if (moshiCodeGenEnabled.getOrElse(false)) {
-      featuresEnabled += Features.MoshiCodeGen
+    if (Features.MoshiCodeGen in features) {
       if (!Features.MoshiCodeGen.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.MoshiCodeGen
       }
     }
-    if (circuitCodeGenEnabled.getOrElse(false)) {
-      featuresEnabled += Features.CircuitInject
+    if (Features.CircuitInject in features) {
       if (!Features.CircuitInject.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.CircuitInject
       }
     }
     if (parcelizeEnabled) {
-      featuresEnabled += Features.Parcelize
       if (!Features.Parcelize.hasAnnotationsUsedIn(srcsDir)) {
         featuresToRemove += Features.Parcelize
       }
     }
 
-    val topography =
-      ModuleTopography(
-        name = projectName.get(),
-        gradlePath = projectPath.get(),
-        features = featuresEnabled.toSortedSet(compareBy { it.name }),
-      )
-
-    JsonWriter.of(topographyOutputFile.asFile.get().sink().buffer()).use {
-      MOSHI.adapter<ModuleTopography>().toJson(it, topography)
-    }
     JsonWriter.of(featuresToRemoveOutputFile.asFile.get().sink().buffer()).use {
       MOSHI.adapter<Set<ModuleFeature>>()
         .toJson(it, featuresToRemove.toSortedSet(compareBy { it.name }))
@@ -259,70 +376,5 @@ public abstract class ModuleTopographyTask : DefaultTask() {
         }
         false
       }
-  }
-
-  internal companion object {
-    fun register(
-      project: Project,
-      foundryExtension: FoundryExtension,
-    ): TaskProvider<ModuleTopographyTask> {
-      val viewBindingEnabled =
-        project.provider { foundryExtension.androidHandler.featuresHandler.viewBindingEnabled() }
-      val task =
-        project.tasks.register<ModuleTopographyTask>("moduleTopography") {
-          projectName.set(project.name)
-          projectPath.set(project.path)
-          projectDirProperty.setDisallowChanges(project.layout.projectDirectory)
-          moshiCodeGenEnabled.setDisallowChanges(
-            foundryExtension.featuresHandler.moshiHandler.moshiCodegen
-          )
-          circuitCodeGenEnabled.setDisallowChanges(
-            foundryExtension.featuresHandler.circuitHandler.codegen
-          )
-          daggerEnabled.setDisallowChanges(foundryExtension.featuresHandler.daggerHandler.enabled)
-          daggerCompilerEnabled.setDisallowChanges(
-            foundryExtension.featuresHandler.daggerHandler.useDaggerCompiler
-          )
-          composeEnabled.setDisallowChanges(foundryExtension.featuresHandler.composeHandler.enabled)
-          androidTestEnabled.setDisallowChanges(
-            foundryExtension.androidHandler.featuresHandler.androidTest
-          )
-          robolectricEnabled.setDisallowChanges(
-            foundryExtension.androidHandler.featuresHandler.robolectric
-          )
-          this.viewBindingEnabled.setDisallowChanges(viewBindingEnabled)
-          topographyOutputFile.setDisallowChanges(
-            project.layout.buildDirectory.file("foundry/topography/topography.json")
-          )
-          featuresToRemoveOutputFile.setDisallowChanges(
-            project.layout.buildDirectory.file("foundry/topography/featuresToRemove.json")
-          )
-
-          // Depend on source-gen tasks
-
-          // Kapt
-          dependsOn(project.tasks.withType(KaptGenerateStubs::class.java))
-          dependsOn(project.tasks.withType(KaptTask::class.java))
-          // KSP
-          dependsOn(project.tasks.withType(KspTask::class.java))
-          dependsOn(project.tasks.withType(KspAATask::class.java))
-          // ViewBinding
-          dependsOn(project.tasks.withType(DataBindingGenBaseClassesTask::class.java))
-        }
-
-      // No easy way to query all plugin IDs, so we use an internal Gradle API
-      val pluginRegistry = project.serviceOf<PluginRegistry>()
-      project.plugins.configureEach {
-        val pluginType = this::class.java
-        val id = pluginRegistry.findPluginForClass(pluginType).getOrNull()?.id
-        if (id == null) {
-          project.logger.debug("Could not read plugin ID for type '$pluginType'")
-          return@configureEach
-        }
-        project.logger.debug("Reading plugin ID '$id' for type '$pluginType'")
-        project.pluginManager.withPlugin(id) { task.configure { pluginsProperty.add(id) } }
-      }
-      return task
-    }
   }
 }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -25,6 +25,7 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.adapter
 import foundry.cli.walkEachFile
 import foundry.gradle.FoundryExtension
+import foundry.gradle.FoundryProperties
 import foundry.gradle.properties.setDisallowChanges
 import foundry.gradle.register
 import foundry.gradle.serviceOf
@@ -107,6 +108,7 @@ public abstract class ModuleTopographyTask : DefaultTask() {
     fun register(
       project: Project,
       foundryExtension: FoundryExtension,
+      foundryProperties: FoundryProperties,
     ): TaskProvider<ModuleTopographyTask> {
       val task =
         project.tasks.register<ModuleTopographyTask>("moduleTopography") {
@@ -172,17 +174,19 @@ public abstract class ModuleTopographyTask : DefaultTask() {
         project.pluginManager.withPlugin(id) { task.configure { pluginsProperty.add(id) } }
       }
 
-      registerValidationTask(project, task)
+      registerValidationTask(project, task, foundryProperties)
       return task
     }
 
     fun registerValidationTask(
       project: Project,
       topographyTask: TaskProvider<ModuleTopographyTask>,
+      foundryProperties: FoundryProperties,
     ) {
       project.tasks.register<ValidateModuleTopographyTask>("validateModuleTopography") {
         topographyJson.set(topographyTask.flatMap { it.topographyOutputFile })
         projectDirProperty.set(project.layout.projectDirectory)
+        autoFix.convention(foundryProperties.topographyAutoFix)
         featuresToRemoveOutputFile.setDisallowChanges(
           project.layout.buildDirectory.file("foundry/topography/validate/featuresToRemove.json")
         )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -45,6 +45,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -64,6 +65,7 @@ private fun Provider<Boolean>.associateWithFeature(
   return map { mapOf(feature.name to it) }
 }
 
+@CacheableTask
 public abstract class ModuleTopographyTask : DefaultTask() {
   @get:Input public abstract val projectName: Property<String>
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package foundry.gradle.model
+package foundry.gradle.topography
 
 import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask
 import com.google.devtools.ksp.gradle.KspAATask
 import com.google.devtools.ksp.gradle.KspTask
-import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.adapter
 import foundry.cli.walkEachFile
@@ -326,146 +325,4 @@ public abstract class ModuleTopographyTask : DefaultTask() {
       return task
     }
   }
-}
-
-@JsonClass(generateAdapter = true)
-public data class ModuleTopography(
-  val name: String,
-  val gradlePath: String,
-  val features: Set<ModuleFeature>,
-)
-
-@JsonClass(generateAdapter = true)
-public data class ModuleFeature(
-  val name: String,
-  val removalMessage: String,
-  /** Generated sources root dir, if any. Note that descendants are checked */
-  val generatedSourcesDir: String? = null,
-  val generatedSourcesExtensions: Set<String> = emptySet(),
-  val matchingText: Set<String> = emptySet(),
-  val matchingAnnotationsExtensions: Set<String> = emptySet(),
-  /** If specified, looks for any sources in this dir */
-  val matchingSourcesDir: String? = null,
-)
-
-// TODO eventually move these to JSON configs
-internal object Features {
-  internal val AndroidTest =
-    ModuleFeature(
-      name = "androidTest",
-      removalMessage = "Remove foundry.android.features.androidTest from your build file",
-      matchingSourcesDir = "src/androidTest",
-    )
-
-  internal val Robolectric =
-    ModuleFeature(
-      name = "robolectric",
-      removalMessage = "Remove foundry.android.features.robolectric from your build file",
-      matchingSourcesDir = "src/test",
-    )
-
-  internal val Compose =
-    ModuleFeature(
-      name = "compose",
-      removalMessage = "Remove foundry.features.compose from your build file",
-      matchingText = setOf("@Composable"),
-      matchingAnnotationsExtensions = setOf("kt"),
-    )
-
-  internal val Dagger =
-    ModuleFeature(
-      name = "dagger",
-      removalMessage = "Remove foundry.features.dagger from your build file",
-      matchingText =
-        setOf(
-          "@Inject",
-          "@AssistedInject",
-          "@ContributesTo",
-          "@ContributesBinding",
-          "@ContributesMultibinding",
-          "@Module",
-          "@Component",
-          "@Subcomponent",
-          "@MergeComponent",
-          "@MergeSubcomponent",
-          "@MergeModules",
-          "@MergeInterfaces",
-          "@ContributesSubcomponent",
-          "import dagger.",
-        ),
-      matchingAnnotationsExtensions = setOf("kt", "java"),
-    )
-
-  internal val DaggerCompiler =
-    ModuleFeature(
-      name = "dagger-compiler",
-      removalMessage = "Remove foundry.features.dagger.mergeComponents from your build file",
-      matchingText =
-        setOf(
-          "@Component",
-          "@Subcomponent",
-          "@MergeComponent",
-          "@MergeSubcomponent",
-          "@MergeModules",
-          "@MergeInterfaces",
-          "@ContributesSubcomponent",
-          // TODO configurable custom annotations? Or we just need to search generated sources too
-          "@CircuitInject",
-          "@FeatureFlags",
-          "@GuinnessApi",
-          "@SlackRemotePreferences",
-          "@WorkRequestIn",
-        ),
-      matchingAnnotationsExtensions = setOf("kt", "java"),
-      generatedSourcesDir = "build/generated/source/kapt",
-      generatedSourcesExtensions = setOf("java"),
-    )
-
-  internal val MoshiCodeGen =
-    ModuleFeature(
-      name = "moshi-codegen",
-      removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
-      matchingText = setOf("@JsonClass"),
-      matchingAnnotationsExtensions = setOf("kt"),
-    )
-
-  internal val CircuitInject =
-    ModuleFeature(
-      name = "circuit-inject",
-      removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
-      matchingText = setOf("@CircuitInject"),
-      matchingAnnotationsExtensions = setOf("kt"),
-    )
-
-  internal val Parcelize =
-    ModuleFeature(
-      name = "parcelize",
-      removalMessage = "Remove the parcelize plugin from your build file",
-      matchingText = setOf("@Parcelize"),
-      matchingAnnotationsExtensions = setOf("kt"),
-    )
-
-  internal val Ksp =
-    ModuleFeature(
-      name = "ksp",
-      removalMessage = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
-      generatedSourcesDir = "build/generated/ksp",
-      // Don't specify extensions because KAPT can generate anything into resources
-    )
-
-  internal val Kapt =
-    ModuleFeature(
-      name = "kapt",
-      removalMessage = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
-      generatedSourcesDir = "build/generated/source/kapt",
-      // Don't specify extensions because KSP can generate anything into resources
-    )
-
-  internal val ViewBinding =
-    ModuleFeature(
-      name = "viewbinding",
-      removalMessage = "Remove android.buildFeatures.viewBinding from your build file",
-      generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
-      generatedSourcesExtensions = setOf("java"),
-    )
 }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foundry.gradle.topography
 
 import com.squareup.moshi.JsonClass

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -1,0 +1,145 @@
+package foundry.gradle.topography
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+public data class ModuleTopography(
+  val name: String,
+  val gradlePath: String,
+  val features: Set<ModuleFeature>,
+)
+
+@JsonClass(generateAdapter = true)
+public data class ModuleFeature(
+  val name: String,
+  val removalMessage: String,
+  /** Generated sources root dir, if any. Note that descendants are checked */
+  val generatedSourcesDir: String? = null,
+  val generatedSourcesExtensions: Set<String> = emptySet(),
+  val matchingText: Set<String> = emptySet(),
+  val matchingAnnotationsExtensions: Set<String> = emptySet(),
+  /** If specified, looks for any sources in this dir */
+  val matchingSourcesDir: String? = null,
+)
+
+// TODO eventually move these to JSON configs
+internal object Features {
+  internal val AndroidTest =
+    ModuleFeature(
+      name = "androidTest",
+      removalMessage = "Remove foundry.android.features.androidTest from your build file",
+      matchingSourcesDir = "src/androidTest",
+    )
+
+  internal val Robolectric =
+    ModuleFeature(
+      name = "robolectric",
+      removalMessage = "Remove foundry.android.features.robolectric from your build file",
+      matchingSourcesDir = "src/test",
+    )
+
+  internal val Compose =
+    ModuleFeature(
+      name = "compose",
+      removalMessage = "Remove foundry.features.compose from your build file",
+      matchingText = setOf("@Composable"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val Dagger =
+    ModuleFeature(
+      name = "dagger",
+      removalMessage = "Remove foundry.features.dagger from your build file",
+      matchingText =
+        setOf(
+          "@Inject",
+          "@AssistedInject",
+          "@ContributesTo",
+          "@ContributesBinding",
+          "@ContributesMultibinding",
+          "@Module",
+          "@Component",
+          "@Subcomponent",
+          "@MergeComponent",
+          "@MergeSubcomponent",
+          "@MergeModules",
+          "@MergeInterfaces",
+          "@ContributesSubcomponent",
+          "import dagger.",
+        ),
+      matchingAnnotationsExtensions = setOf("kt", "java"),
+    )
+
+  internal val DaggerCompiler =
+    ModuleFeature(
+      name = "dagger-compiler",
+      removalMessage = "Remove foundry.features.dagger.mergeComponents from your build file",
+      matchingText =
+        setOf(
+          "@Component",
+          "@Subcomponent",
+          "@MergeComponent",
+          "@MergeSubcomponent",
+          "@MergeModules",
+          "@MergeInterfaces",
+          "@ContributesSubcomponent",
+          // TODO configurable custom annotations? Or we just need to search generated sources too
+          "@CircuitInject",
+          "@FeatureFlags",
+          "@GuinnessApi",
+          "@SlackRemotePreferences",
+          "@WorkRequestIn",
+        ),
+      matchingAnnotationsExtensions = setOf("kt", "java"),
+      generatedSourcesDir = "build/generated/source/kapt",
+      generatedSourcesExtensions = setOf("java"),
+    )
+
+  internal val MoshiCodeGen =
+    ModuleFeature(
+      name = "moshi-codegen",
+      removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
+      matchingText = setOf("@JsonClass"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val CircuitInject =
+    ModuleFeature(
+      name = "circuit-inject",
+      removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
+      matchingText = setOf("@CircuitInject"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val Parcelize =
+    ModuleFeature(
+      name = "parcelize",
+      removalMessage = "Remove the parcelize plugin from your build file",
+      matchingText = setOf("@Parcelize"),
+      matchingAnnotationsExtensions = setOf("kt"),
+    )
+
+  internal val Ksp =
+    ModuleFeature(
+      name = "ksp",
+      removalMessage = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
+      generatedSourcesDir = "build/generated/ksp",
+      // Don't specify extensions because KAPT can generate anything into resources
+    )
+
+  internal val Kapt =
+    ModuleFeature(
+      name = "kapt",
+      removalMessage = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
+      generatedSourcesDir = "build/generated/source/kapt",
+      // Don't specify extensions because KSP can generate anything into resources
+    )
+
+  internal val ViewBinding =
+    ModuleFeature(
+      name = "viewbinding",
+      removalMessage = "Remove android.buildFeatures.viewBinding from your build file",
+      generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
+      generatedSourcesExtensions = setOf("java"),
+    )
+}

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -123,20 +123,23 @@ internal object KnownFeatures {
       matchingText =
         buildSet {
           addAll(DaggerCompiler.matchingText)
-          setOf(
-            "@Inject",
-            "@AssistedInject",
-            "@ContributesTo",
-            "@ContributesBinding",
-            "@ContributesMultibinding",
-            "@Module",
-            "import dagger.",
-            // TODO configurable custom annotations? Or we just need to search generated sources too
-            "@CircuitInject",
-            "@FeatureFlags",
-            "@GuinnessApi",
-            "@SlackRemotePreferences",
-            "@WorkRequestIn",
+          addAll(
+            setOf(
+              "@Inject",
+              "@AssistedInject",
+              "@ContributesTo",
+              "@ContributesBinding",
+              "@ContributesMultibinding",
+              "@Module",
+              "import dagger.",
+              // TODO configurable custom annotations? Or we just need to search generated sources
+              // too
+              "@CircuitInject",
+              "@FeatureFlags",
+              "@GuinnessApi",
+              "@SlackRemotePreferences",
+              "@WorkRequestIn",
+            )
           )
         },
       matchingTextFileExtensions = setOf("kt", "java"),

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -1,12 +1,13 @@
 package foundry.gradle.topography
 
 import com.squareup.moshi.JsonClass
+import kotlin.reflect.full.declaredMemberProperties
 
 @JsonClass(generateAdapter = true)
 public data class ModuleTopography(
   val name: String,
   val gradlePath: String,
-  val features: Set<ModuleFeature>,
+  val features: Set<String>,
   val plugins: Set<String>,
 )
 
@@ -23,8 +24,18 @@ public data class ModuleFeature(
   val matchingSourcesDir: String? = null,
 )
 
-// TODO eventually move these to JSON configs
-internal object Features {
+// TODO eventually move these to JSON configs?
+internal object KnownFeatures {
+  fun load(): Map<String, ModuleFeature> {
+    return KnownFeatures::class
+      .declaredMemberProperties
+      .filter { it.returnType.classifier == ModuleFeature::class }
+      .associate {
+        val feature = it.get(KnownFeatures) as ModuleFeature
+        feature.name to feature
+      }
+  }
+
   internal val AndroidTest =
     ModuleFeature(
       name = "androidTest",

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -17,7 +17,6 @@ package foundry.gradle.topography
 
 import com.squareup.moshi.JsonClass
 import kotlin.reflect.full.declaredMemberProperties
-import org.intellij.lang.annotations.Language
 
 @JsonClass(generateAdapter = true)
 public data class ModuleTopography(
@@ -30,8 +29,9 @@ public data class ModuleTopography(
 @JsonClass(generateAdapter = true)
 public data class ModuleFeature(
   val name: String,
-  val removalMessage: String,
-  @Language("RegExp") val removalRegex: String?,
+  val explanation: String,
+  val advice: String,
+  val removalPatterns: Set<Regex>?,
   /**
    * Generated sources root dir relative to the project dir, if any. Files are checked recursively.
    */
@@ -62,59 +62,42 @@ internal object KnownFeatures {
   internal val AndroidTest =
     ModuleFeature(
       name = "androidTest",
-      removalMessage = "Remove foundry.android.features.androidTest from your build file",
-      removalRegex = "\\bandroidTest\\(\\)",
+      explanation =
+        "The `androidTest()` feature was requested but no sources were found at `src/androidTest/**`",
+      advice = "Remove `foundry.android.features.androidTest` from your build file",
+      removalPatterns = setOf("\\bandroidTest\\(\\)".toRegex()),
       matchingSourcesDir = "src/androidTest",
     )
 
   internal val Robolectric =
     ModuleFeature(
       name = "robolectric",
-      removalMessage = "Remove foundry.android.features.robolectric from your build file",
-      removalRegex = "\\brobolectric\\(\\)",
+      explanation =
+        "The `robolectric()` feature was requested but no sources were found at `src/test/**`",
+      advice = "Remove `foundry.android.features.robolectric` from your build file",
+      removalPatterns = setOf("\\brobolectric\\(\\)".toRegex()),
       matchingSourcesDir = "src/test",
     )
 
   internal val Compose =
     ModuleFeature(
       name = "compose",
-      removalMessage =
-        "Remove foundry.features.compose from your build file or use foundry.features.composeRuntimeOnly()",
-      removalRegex = "\\bcompose\\(\\)",
+      explanation =
+        "The `compose()` feature (and thus compose-compiler) was requested but no `@Composable` annotations were found in sources",
+      advice =
+        "Remove `foundry.features.compose` from your build file or use `foundry.features.composeRuntimeOnly()`",
+      removalPatterns = setOf("\\bcompose\\(\\)".toRegex()),
       matchingText = setOf("@Composable"),
       matchingTextFileExtensions = setOf("kt"),
-    )
-
-  internal val Dagger =
-    ModuleFeature(
-      name = "dagger",
-      removalMessage = "Remove foundry.features.dagger from your build file",
-      removalRegex = "\\bdagger\\(\\)",
-      matchingText =
-        setOf(
-          "@Inject",
-          "@AssistedInject",
-          "@ContributesTo",
-          "@ContributesBinding",
-          "@ContributesMultibinding",
-          "@Module",
-          "@Component",
-          "@Subcomponent",
-          "@MergeComponent",
-          "@MergeSubcomponent",
-          "@MergeModules",
-          "@MergeInterfaces",
-          "@ContributesSubcomponent",
-          "import dagger.",
-        ),
-      matchingTextFileExtensions = setOf("kt", "java"),
     )
 
   internal val DaggerCompiler =
     ModuleFeature(
       name = "dagger-compiler",
-      removalMessage = "Remove foundry.features.dagger.mergeComponents from your build file",
-      removalRegex = "\\bmergeComponents\\(\\)",
+      explanation =
+        "The `mergeComponents()` feature (and thus dagger-compiler/KAPT) was requested but no corresponding Merge*/*Component annotations were found in sources",
+      advice = "Remove `foundry.features.dagger.mergeComponents` from your build file",
+      removalPatterns = setOf("\\bmergeComponents\\(\\)".toRegex()),
       matchingText =
         setOf(
           "@Component",
@@ -124,23 +107,48 @@ internal object KnownFeatures {
           "@MergeModules",
           "@MergeInterfaces",
           "@ContributesSubcomponent",
-          // TODO configurable custom annotations? Or we just need to search generated sources too
-          "@CircuitInject",
-          "@FeatureFlags",
-          "@GuinnessApi",
-          "@SlackRemotePreferences",
-          "@WorkRequestIn",
         ),
       matchingTextFileExtensions = setOf("kt", "java"),
       generatedSourcesDir = "build/generated/source/kapt",
       generatedSourcesExtensions = setOf("java"),
     )
 
+  internal val Dagger =
+    ModuleFeature(
+      name = "dagger",
+      explanation =
+        "The `dagger()` feature (and thus Anvil/KSP) was requested but no Dagger/Anvil annotations were found in sources",
+      advice = "Remove `foundry.features.dagger` from your build file",
+      removalPatterns = setOf("\\bdagger\\(\\)".toRegex()),
+      matchingText =
+        buildSet {
+          addAll(DaggerCompiler.matchingText)
+          setOf(
+            "@Inject",
+            "@AssistedInject",
+            "@ContributesTo",
+            "@ContributesBinding",
+            "@ContributesMultibinding",
+            "@Module",
+            "import dagger.",
+            // TODO configurable custom annotations? Or we just need to search generated sources too
+            "@CircuitInject",
+            "@FeatureFlags",
+            "@GuinnessApi",
+            "@SlackRemotePreferences",
+            "@WorkRequestIn",
+          )
+        },
+      matchingTextFileExtensions = setOf("kt", "java"),
+    )
+
   internal val MoshiCodeGen =
     ModuleFeature(
       name = "moshi-codegen",
-      removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
-      removalRegex = null,
+      explanation =
+        "The `moshi(codeGen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
+      advice = "Remove `foundry.features.moshi.codeGen` from your build file",
+      removalPatterns = null,
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -148,8 +156,11 @@ internal object KnownFeatures {
   internal val CircuitInject =
     ModuleFeature(
       name = "circuit-inject",
-      removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
-      removalRegex = null,
+      explanation =
+        "The `circuit(codegen = true)` feature (and thus the KSP) was requested but no `@CircuitInject` annotations were found in sources",
+      advice =
+        "Remove `foundry.features.circuit.codegen` from your build file or set codegen to false (i.e. `circuit(codegen = false)`)",
+      removalPatterns = null,
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -157,8 +168,11 @@ internal object KnownFeatures {
   internal val Parcelize =
     ModuleFeature(
       name = "parcelize",
-      removalMessage = "Remove the parcelize plugin from your build file",
-      removalRegex = "\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)",
+      explanation =
+        "The parcelize plugin (and thus its compiler plugin) was requested but no `@Parcelize` annotations were found in sources",
+      advice = "Remove the parcelize plugin from your build file",
+      removalPatterns =
+        setOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex()),
       matchingText = setOf("@Parcelize"),
       matchingTextFileExtensions = setOf("kt"),
       matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
@@ -167,8 +181,11 @@ internal object KnownFeatures {
   internal val Ksp =
     ModuleFeature(
       name = "ksp",
-      removalMessage = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
-      removalRegex = "\\balias\\(libs\\.plugins\\.ksp\\)",
+      explanation =
+        "The KSP plugin was requested but no generated files were found in `build/generated/ksp`",
+      advice = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
+      removalPatterns =
+        setOf("\\balias\\(libs\\.plugins\\.ksp\\)".toRegex(), "\\bksp\\([a-zA-Z.-]*\\)".toRegex()),
       generatedSourcesDir = "build/generated/ksp",
       matchingPlugin = "com.google.devtools.ksp",
       // Don't specify extensions because KAPT can generate anything into resources
@@ -177,18 +194,26 @@ internal object KnownFeatures {
   internal val Kapt =
     ModuleFeature(
       name = "kapt",
-      removalMessage = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
-      removalRegex = "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)",
+      explanation =
+        "The KAPT plugin was requested but no generated files were found in `build/generated/source/kapt`",
+      advice = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
+      removalPatterns =
+        setOf(
+          "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)".toRegex(),
+          "\\bkapt\\([a-zA-Z.-]*\\)".toRegex(),
+        ),
       generatedSourcesDir = "build/generated/source/kapt",
       matchingPlugin = "org.jetbrains.kotlin.kapt",
-      // Don't specify extensions because KSP can generate anything into resources
+      // Don't specify file extensions because KSP can generate anything into resources
     )
 
   internal val ViewBinding =
     ModuleFeature(
       name = "viewbinding",
-      removalMessage = "Remove android.buildFeatures.viewBinding from your build file",
-      removalRegex = "\\viewBinding = true",
+      explanation =
+        "Android ViewBinding was enabled but no generated viewbinding sources were found in `build/generated/data_binding_base_class_source_out`",
+      advice = "Remove android.buildFeatures.viewBinding from your build file",
+      removalPatterns = setOf("\\bviewBinding = true".toRegex()),
       generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
       generatedSourcesExtensions = setOf("java"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -15,13 +15,19 @@ public data class ModuleTopography(
 public data class ModuleFeature(
   val name: String,
   val removalMessage: String,
-  /** Generated sources root dir, if any. Note that descendants are checked */
+  /**
+   * Generated sources root dir relative to the project dir, if any. Files are checked recursively.
+   */
   val generatedSourcesDir: String? = null,
   val generatedSourcesExtensions: Set<String> = emptySet(),
   val matchingText: Set<String> = emptySet(),
-  val matchingAnnotationsExtensions: Set<String> = emptySet(),
-  /** If specified, looks for any sources in this dir */
+  val matchingTextFileExtensions: Set<String> = emptySet(),
+  /**
+   * If specified, looks for any sources in this dir relative to the project dir. Files are checked
+   * recursively.
+   */
   val matchingSourcesDir: String? = null,
+  val matchingPlugin: String? = null,
 )
 
 // TODO eventually move these to JSON configs?
@@ -53,9 +59,10 @@ internal object KnownFeatures {
   internal val Compose =
     ModuleFeature(
       name = "compose",
-      removalMessage = "Remove foundry.features.compose from your build file",
+      removalMessage =
+        "Remove foundry.features.compose from your build file or use foundry.features.composeRuntimeOnly()",
       matchingText = setOf("@Composable"),
-      matchingAnnotationsExtensions = setOf("kt"),
+      matchingTextFileExtensions = setOf("kt"),
     )
 
   internal val Dagger =
@@ -79,7 +86,7 @@ internal object KnownFeatures {
           "@ContributesSubcomponent",
           "import dagger.",
         ),
-      matchingAnnotationsExtensions = setOf("kt", "java"),
+      matchingTextFileExtensions = setOf("kt", "java"),
     )
 
   internal val DaggerCompiler =
@@ -102,7 +109,7 @@ internal object KnownFeatures {
           "@SlackRemotePreferences",
           "@WorkRequestIn",
         ),
-      matchingAnnotationsExtensions = setOf("kt", "java"),
+      matchingTextFileExtensions = setOf("kt", "java"),
       generatedSourcesDir = "build/generated/source/kapt",
       generatedSourcesExtensions = setOf("java"),
     )
@@ -112,7 +119,7 @@ internal object KnownFeatures {
       name = "moshi-codegen",
       removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
       matchingText = setOf("@JsonClass"),
-      matchingAnnotationsExtensions = setOf("kt"),
+      matchingTextFileExtensions = setOf("kt"),
     )
 
   internal val CircuitInject =
@@ -120,7 +127,7 @@ internal object KnownFeatures {
       name = "circuit-inject",
       removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
       matchingText = setOf("@CircuitInject"),
-      matchingAnnotationsExtensions = setOf("kt"),
+      matchingTextFileExtensions = setOf("kt"),
     )
 
   internal val Parcelize =
@@ -128,7 +135,8 @@ internal object KnownFeatures {
       name = "parcelize",
       removalMessage = "Remove the parcelize plugin from your build file",
       matchingText = setOf("@Parcelize"),
-      matchingAnnotationsExtensions = setOf("kt"),
+      matchingTextFileExtensions = setOf("kt"),
+      matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
     )
 
   internal val Ksp =
@@ -136,6 +144,7 @@ internal object KnownFeatures {
       name = "ksp",
       removalMessage = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
       generatedSourcesDir = "build/generated/ksp",
+      matchingPlugin = "com.google.devtools.ksp",
       // Don't specify extensions because KAPT can generate anything into resources
     )
 
@@ -144,6 +153,7 @@ internal object KnownFeatures {
       name = "kapt",
       removalMessage = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
       generatedSourcesDir = "build/generated/source/kapt",
+      matchingPlugin = "org.jetbrains.kotlin.kapt",
       // Don't specify extensions because KSP can generate anything into resources
     )
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -2,6 +2,7 @@ package foundry.gradle.topography
 
 import com.squareup.moshi.JsonClass
 import kotlin.reflect.full.declaredMemberProperties
+import org.intellij.lang.annotations.Language
 
 @JsonClass(generateAdapter = true)
 public data class ModuleTopography(
@@ -15,6 +16,7 @@ public data class ModuleTopography(
 public data class ModuleFeature(
   val name: String,
   val removalMessage: String,
+  @Language("RegExp") val removalRegex: String?,
   /**
    * Generated sources root dir relative to the project dir, if any. Files are checked recursively.
    */
@@ -46,6 +48,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "androidTest",
       removalMessage = "Remove foundry.android.features.androidTest from your build file",
+      removalRegex = "\\bandroidTest\\(\\)",
       matchingSourcesDir = "src/androidTest",
     )
 
@@ -53,6 +56,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "robolectric",
       removalMessage = "Remove foundry.android.features.robolectric from your build file",
+      removalRegex = "\\brobolectric\\(\\)",
       matchingSourcesDir = "src/test",
     )
 
@@ -61,6 +65,7 @@ internal object KnownFeatures {
       name = "compose",
       removalMessage =
         "Remove foundry.features.compose from your build file or use foundry.features.composeRuntimeOnly()",
+      removalRegex = "\\bcompose\\(\\)",
       matchingText = setOf("@Composable"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -69,6 +74,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "dagger",
       removalMessage = "Remove foundry.features.dagger from your build file",
+      removalRegex = "\\bdagger\\(\\)",
       matchingText =
         setOf(
           "@Inject",
@@ -93,6 +99,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "dagger-compiler",
       removalMessage = "Remove foundry.features.dagger.mergeComponents from your build file",
+      removalRegex = "\\bmergeComponents\\(\\)",
       matchingText =
         setOf(
           "@Component",
@@ -118,6 +125,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "moshi-codegen",
       removalMessage = "Remove foundry.features.moshi.codeGen from your build file",
+      removalRegex = null,
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -126,6 +134,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "circuit-inject",
       removalMessage = "Remove foundry.features.circuit.codeGen from your build file",
+      removalRegex = null,
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -134,6 +143,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "parcelize",
       removalMessage = "Remove the parcelize plugin from your build file",
+      removalRegex = "\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)",
       matchingText = setOf("@Parcelize"),
       matchingTextFileExtensions = setOf("kt"),
       matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
@@ -143,6 +153,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "ksp",
       removalMessage = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
+      removalRegex = "\\balias\\(libs\\.plugins\\.ksp\\)",
       generatedSourcesDir = "build/generated/ksp",
       matchingPlugin = "com.google.devtools.ksp",
       // Don't specify extensions because KAPT can generate anything into resources
@@ -152,6 +163,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "kapt",
       removalMessage = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
+      removalRegex = "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)",
       generatedSourcesDir = "build/generated/source/kapt",
       matchingPlugin = "org.jetbrains.kotlin.kapt",
       // Don't specify extensions because KSP can generate anything into resources
@@ -161,6 +173,7 @@ internal object KnownFeatures {
     ModuleFeature(
       name = "viewbinding",
       removalMessage = "Remove android.buildFeatures.viewBinding from your build file",
+      removalRegex = "\\viewBinding = true",
       generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
       generatedSourcesExtensions = setOf("java"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -7,6 +7,7 @@ public data class ModuleTopography(
   val name: String,
   val gradlePath: String,
   val features: Set<ModuleFeature>,
+  val plugins: Set<String>,
 )
 
 @JsonClass(generateAdapter = true)

--- a/platforms/intellij/compose/lint-baseline.xml
+++ b/platforms/intellij/compose/lint-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.8.0-alpha01">
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="            markdown!!,"
+        errorLine2="                    ~~">
+        <location
+            file="src/jvmMain/kotlin/foundry/intellij/compose/markdown/ui/MarkdownPanel.kt"
+            line="100"
+            column="21"/>
+    </issue>
+
+</issues>

--- a/platforms/intellij/skate/lint-baseline.xml
+++ b/platforms/intellij/skate/lint-baseline.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.8.0-alpha01">
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="      .map { codeOwnershipMap[it]!! }"
+        errorLine2="                                 ~~">
+        <location
+            file="src/main/kotlin/foundry/intellij/skate/codeowners/CodeOwnerRepository.kt"
+            line="77"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(translatorWarning!!.description).isEqualTo(warningDescription)"
+        errorLine2="                                ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorAnnotatorTest.kt"
+            line="168"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="42"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="64"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="86"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="108"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="125"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assertThat(body!!.text)"
+        errorLine2="                   ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="142"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="  private fun getNamedFunction() = file.findDescendantOfType&lt;KtNamedFunction>()!!"
+        errorLine2="                                                                               ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="153"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    return TranslatorHelper.generateBody(TranslatorHelper.extractBundle(getNamedFunction())!!)"
+        errorLine2="                                                                                           ~~">
+        <location
+            file="src/test/kotlin/foundry/intellij/skate/modeltranslator/TranslatorHelperTest.kt"
+            line="156"
+            column="92"/>
+    </issue>
+
+</issues>

--- a/tools/cli/lint-baseline.xml
+++ b/tools/cli/lint-baseline.xml
@@ -1,5 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.6.1)" variant="all" version="8.8.0-alpha01">
+<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.8.0-alpha01">
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    val results = runs.first().results!!"
+        errorLine2="                                      ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/sarif/ApplyBaselinesToSarifs.kt"
+            line="98"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    val baselineResults = baseline.runs.first().results!!"
+        errorLine2="                                                       ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/sarif/ApplyBaselinesToSarifs.kt"
+            line="99"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="          val originalUri = run.originalURIBaseIDS!!.getValue(SRC_ROOT)"
+        errorLine2="                                                  ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/sarif/MergeSarifReports.kt"
+            line="202"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="  override fun fromJson(reader: JsonReader) = stringAdapter.fromJson(reader)!!.toRegex()"
+        errorLine2="                                                                            ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/util/RegexJsonAdapter.kt"
+            line="29"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    assert(regex!!.pattern == &quot;.*&quot;)"
+        errorLine2="                ~~">
+        <location
+            file="src/test/kotlin/foundry/cli/util/RegexJsonAdapterFactoryTest.kt"
+            line="29"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    val issue = adapter.fromJson(json)!!"
+        errorLine2="                                      ~~">
+        <location
+            file="src/test/kotlin/foundry/cli/shellsentry/ShellSentryConfigTest.kt"
+            line="50"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="    val list = moshi.adapter&lt;List&lt;String>>().fromJson(&quot;&quot;&quot;&quot;foo&quot;&quot;&quot;&quot;)!!"
+        errorLine2="                                                                  ~~">
+        <location
+            file="src/test/kotlin/foundry/cli/util/SingleItemListAdapterTest.kt"
+            line="27"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="              add(collectionTypeAdapter.fromJson(reader)!!)"
+        errorLine2="                                                        ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/util/SingleItemListJsonAdapterFactory.kt"
+            line="67"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="          result = listOf(collectionTypeAdapter.fromJson(reader)!!)"
+        errorLine2="                                                                ~~">
+        <location
+            file="src/main/kotlin/foundry/cli/util/SingleItemListJsonAdapterFactory.kt"
+            line="79"
+            column="65"/>
+    </issue>
 
     <issue
         id="MoshiUsageNonMoshiClassPlatform"
@@ -19,7 +118,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="132"
+            line="134"
             column="5"/>
     </issue>
 
@@ -30,7 +129,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="146"
+            line="148"
             column="5"/>
     </issue>
 
@@ -41,7 +140,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="160"
+            line="162"
             column="5"/>
     </issue>
 
@@ -52,7 +151,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="174"
+            line="176"
             column="5"/>
     </issue>
 
@@ -63,7 +162,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="188"
+            line="190"
             column="5"/>
     </issue>
 
@@ -74,7 +173,7 @@
         errorLine2="    ~~~~~">
         <location
             file="src/test/kotlin/foundry/cli/shellsentry/ResultProcessorTest.kt"
-            line="223"
+            line="225"
             column="5"/>
     </issue>
 

--- a/tools/cli/src/main/kotlin/foundry/cli/CliUtil.kt
+++ b/tools/cli/src/main/kotlin/foundry/cli/CliUtil.kt
@@ -29,6 +29,7 @@ import kotlin.io.path.FileVisitorBuilder
 import kotlin.io.path.extension
 import kotlin.io.path.name
 import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.notExists
 import kotlin.io.path.visitFileTree
 
 /**
@@ -60,6 +61,7 @@ public fun Path.walkEachFile(
   followLinks: Boolean = false,
   builderAction: FileVisitorBuilder.() -> Unit = {},
 ): Sequence<Path> {
+  if (notExists()) return emptySequence()
   val files = mutableListOf<Path>()
   visitFileTree(maxDepth, followLinks) {
     builderAction()

--- a/tools/skippy/lint-baseline.xml
+++ b/tools/skippy/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.8.0-alpha01" type="baseline" client="gradle" dependencies="false" name="AGP (8.7.1)" variant="all" version="8.8.0-alpha01">
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="  return filterKeys { it != null }.mapKeys { it.key!! }"
+        errorLine2="                                                   ~~">
+        <location
+            file="src/main/kotlin/foundry/skippy/AffectedProjectsComputer.kt"
+            line="338"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="      moshi.adapter&lt;List&lt;SkippyConfig>>().fromJson(config.readText())!!.associateBy { it.tool }"
+        errorLine2="                                                                     ~~">
+        <location
+            file="src/main/kotlin/foundry/skippy/ComputeAffectedProjectsCli.kt"
+            line="113"
+            column="70"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
This PR introduces two new tasks to Foundry.

1. `ModuleTopographyTask` (name: `moduleTopography`). This task reads various information about a module's build features and dumps them to a JSON file. At the moment these features hard coded directly in source, but in the future we could look at trying to make this a more configurable JSON format that could be configurable per-repo. The idea is that this offers a way to get insight into what build features a module has in a way that other tools can then read from. For example - mod score could read this rather than its current, non-reusable implementation.
2. `ValidateModuleTopographyTask` (name: `validateModuleTopography`). This is a sister task to the first one, reading its outputs and then just validating that each _declared_ feature is actually _used_. If it's declared but not used, it fails validation and can optionally be auto-fixed.

Next after this PR:
- Make mod score read this
- Explore consumer-side JSON config files
- Add more detectable features
  - Explore sourcing from DAGP outputs to determine other features like resources usage or android API/aar dep usage.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->