### PR TITLE
Paper over test fixture dependency cycles in mod score computation

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
@@ -334,8 +334,6 @@ public abstract class ModuleStatsAggregatorTask : DefaultTask() {
         } catch (e: GraphCycleProhibitedException) {
           // Surprisingly, not unexpected. This can happen when project A has a compileOnly
           // dependency on project B and project B has a testImplementation dependency on project A.
-          // This _only_ happens with model and test-model, which we should just modularize out to a
-          // third "model-tests" module
           if ("model" !in subproject || "model" !in dependency) {
             if (subproject.contains("test-fixtures") xor dependency.contains("test-fixtures")) {
               // This is a big bandaid over the ability for projects to depend own their own test

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
@@ -339,11 +339,9 @@ public abstract class ModuleStatsAggregatorTask : DefaultTask() {
           if ("model" !in subproject || "model" !in dependency) {
             if (subproject.contains("test-fixtures") xor dependency.contains("test-fixtures")) {
               // This is a big bandaid over the ability for projects to depend own their own test
-              // fixtures, which
-              // breaks the cycle in these scenarios.
+              // fixtures, which breaks the cycle in these scenarios.
               // We allow this specific case, ideally in the future with native testFixtures()
-              // support this
-              // would just go away.
+              // support this would just go away.
             } else {
               throw RuntimeException(
                 "Cycle from $subproject to $dependency. Please modularize this better!",

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
@@ -68,6 +68,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jgrapht.alg.scoring.BetweennessCentrality
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.DirectedAcyclicGraph
+import org.jgrapht.graph.GraphCycleProhibitedException
 
 public object ModuleStatsTasks {
   public const val AGGREGATOR_NAME: String = "aggregateModuleStats"
@@ -330,16 +331,25 @@ public abstract class ModuleStatsAggregatorTask : DefaultTask() {
         graph.addVertex(dependency)
         try {
           graph.addEdge(subproject, dependency)
-        } catch (e: IllegalArgumentException) {
+        } catch (e: GraphCycleProhibitedException) {
           // Surprisingly, not unexpected. This can happen when project A has a compileOnly
           // dependency on project B and project B has a testImplementation dependency on project A.
           // This _only_ happens with model and test-model, which we should just modularize out to a
           // third "model-tests" module
           if ("model" !in subproject || "model" !in dependency) {
-            throw RuntimeException(
-              "Cycle from $subproject to $dependency. Please modularize this better!",
-              e,
-            )
+            if (subproject.contains("test-fixtures") xor dependency.contains("test-fixtures")) {
+              // This is a big bandaid over the ability for projects to depend own their own test
+              // fixtures, which
+              // breaks the cycle in these scenarios.
+              // We allow this specific case, ideally in the future with native testFixtures()
+              // support this
+              // would just go away.
+            } else {
+              throw RuntimeException(
+                "Cycle from $subproject to $dependency. Please modularize this better!",
+                e,
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
See the comments in code for why we're allowing this. Hopefully just a stopgap until we can finally use native test fixtures everywhere.

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->