### PR TITLE
Improve detekt exclusion of build dir files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- [gradle] Improve Detekt configuration to better ignore generated source files.
+
 0.22.3
 ------
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/lint/DetektTasks.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/lint/DetektTasks.kt
@@ -111,15 +111,16 @@ internal object DetektTasks {
         }
 
       // Duplicate configs due to https://github.com/detekt/detekt/issues/5940
+      val buildDir = project.layout.buildDirectory.asFile.get().canonicalPath
       project.tasks.configureEach<Detekt> {
         this.jvmTarget = foundryProperties.versions.jvmTarget.get().toString()
-        exclude("**/build/**")
+        exclude { it.file.canonicalPath.startsWith(buildDir) }
         // Cannot use setDisallowChanges because this property is set without a convention in Detekt
         jdkHome.set(sneakyNull<Directory>())
       }
       project.tasks.configureEach<DetektCreateBaselineTask> {
         this.jvmTarget = foundryProperties.versions.jvmTarget.get().toString()
-        exclude("**/build/**")
+        exclude { it.file.canonicalPath.startsWith(buildDir) }
         // Cannot use setDisallowChanges because this property is set without a convention in Detekt
         jdkHome.set(sneakyNull<Directory>())
       }


### PR DESCRIPTION
Detekt's exclude() API is quite weird and pattern matches don't work because it only starts from src roots

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->