### PR TITLE
Fix snapshot tests job on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           if: failure()
           uses: actions/upload-artifact@v4
           with:
-            name: reports
+            name: snapshot-reports
             path: |
               **/build/reports/**
               **/src/jvmTest/snapshots/**/*_compare.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
             name: snapshot-reports
             path: |
               **/build/reports/**
-              **/src/jvmTest/snapshots/**/*_compare.png
+              **/build/outputs/roborazzi/*.png
 
   publish-snapshot:
     name: 'Publish snapshot (main only)'


### PR DESCRIPTION
- Fix location of roborazzi outputs (was previously just pointing at the the main sources rather than where reports)
- Fix the reports file name to disambiguate from the usual job

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->