### PR TITLE
Add another compose matching text

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/models.kt
@@ -106,7 +106,7 @@ internal object KnownFeatures {
       advice =
         "Remove `foundry.features.compose` from your build file or use `foundry.features.composeRuntimeOnly()`",
       removalPatterns = setOf("\\bcompose\\(\\)".toRegex()),
-      matchingText = setOf("@Composable"),
+      matchingText = setOf("@Composable", "setContent {"),
       matchingTextFileExtensions = setOf("kt"),
     )
 


### PR DESCRIPTION
There are some projects that don't have their own top-level composables but do call `setContent {}` in composable contexts we can try to catch

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->