### PR TITLE
Small topography fixes

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/stats/ModuleStats.kt
@@ -34,7 +34,7 @@ import foundry.gradle.namedLazy
 import foundry.gradle.properties.mapToBoolean
 import foundry.gradle.properties.setDisallowChanges
 import foundry.gradle.register
-import foundry.gradle.tasks.mustRunAfterSourceGeneratingTasks
+import foundry.gradle.tasks.dependsOnSourceGeneratingTasks
 import foundry.gradle.topography.DefaultFeatures
 import foundry.gradle.topography.ModuleTopography
 import foundry.gradle.topography.ModuleTopographyTask
@@ -175,7 +175,7 @@ public object ModuleStatsTasks {
           }
           // Don't depend on compiler tasks. Technically doesn't cover javac apt but tbh we don't
           // really support that
-          locTask.mustRunAfterSourceGeneratingTasks(project, includeCompilerTasks = false)
+          locTask.dependsOnSourceGeneratingTasks(project, includeCompilerTasks = false)
         }
       }
     }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
@@ -63,7 +63,6 @@ internal fun TaskProvider<*>.dependsOnSourceGeneratingTasks(
   project.pluginManager.withPlugin("app.cash.sqldelight") {
     configure {
       dependsOn(project.tasks.withType(SqlDelightTask::class.java))
-      dependsOn(project.tasks.withType(GenerateSchemaTask::class.java))
     }
   }
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
@@ -15,7 +15,6 @@
  */
 package foundry.gradle.tasks
 
-import app.cash.sqldelight.gradle.GenerateSchemaTask
 import app.cash.sqldelight.gradle.SqlDelightTask
 import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask
 import com.google.devtools.ksp.gradle.KspAATask
@@ -61,9 +60,7 @@ internal fun TaskProvider<*>.dependsOnSourceGeneratingTasks(
 
   // SqlDelight
   project.pluginManager.withPlugin("app.cash.sqldelight") {
-    configure {
-      dependsOn(project.tasks.withType(SqlDelightTask::class.java))
-    }
+    configure { dependsOn(project.tasks.withType(SqlDelightTask::class.java)) }
   }
 
   // Wire

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/tasks/TaskExtensions.kt
@@ -34,48 +34,52 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * @param includeCompilerTasks some compiler tasks like javac and kotlinc can produce new source
  *   files too, namely during annotation processing.
  */
-internal fun TaskProvider<*>.mustRunAfterSourceGeneratingTasks(
+internal fun TaskProvider<*>.dependsOnSourceGeneratingTasks(
   project: Project,
   includeCompilerTasks: Boolean,
 ) {
   // Kapt
   project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
     configure {
-      mustRunAfter(project.tasks.withType(KaptGenerateStubs::class.java))
-      mustRunAfter(project.tasks.withType(KaptTask::class.java))
+      dependsOn(project.tasks.withType(KaptGenerateStubs::class.java))
+      dependsOn(project.tasks.withType(KaptTask::class.java))
     }
   }
+
   // KSP
   project.pluginManager.withPlugin("com.google.devtools.ksp") {
     configure {
-      mustRunAfter(project.tasks.withType(KspTask::class.java))
-      mustRunAfter(project.tasks.withType(KspAATask::class.java))
+      dependsOn(project.tasks.withType(KspTask::class.java))
+      dependsOn(project.tasks.withType(KspAATask::class.java))
     }
   }
+
   // ViewBinding
   project.pluginManager.withPlugin("com.android.base") {
-    configure { mustRunAfter(project.tasks.withType(DataBindingGenBaseClassesTask::class.java)) }
+    configure { dependsOn(project.tasks.withType(DataBindingGenBaseClassesTask::class.java)) }
   }
+
   // SqlDelight
   project.pluginManager.withPlugin("app.cash.sqldelight") {
     configure {
-      mustRunAfter(project.tasks.withType(SqlDelightTask::class.java))
-      mustRunAfter(project.tasks.withType(GenerateSchemaTask::class.java))
+      dependsOn(project.tasks.withType(SqlDelightTask::class.java))
+      dependsOn(project.tasks.withType(GenerateSchemaTask::class.java))
     }
   }
+
   // Wire
   project.pluginManager.withPlugin("com.squareup.wire") {
-    configure { mustRunAfter(project.tasks.withType(WireTask::class.java)) }
+    configure { dependsOn(project.tasks.withType(WireTask::class.java)) }
   }
 
   if (includeCompilerTasks) {
     project.pluginManager.withPlugin("org.jetbrains.kotlin.base") {
-      configure { mustRunAfter(project.tasks.withType(KotlinCompile::class.java)) }
+      configure { dependsOn(project.tasks.withType(KotlinCompile::class.java)) }
       // KGP may create JavaCompile tasks
-      configure { mustRunAfter(project.tasks.withType(JavaCompile::class.java)) }
+      configure { dependsOn(project.tasks.withType(JavaCompile::class.java)) }
     }
     project.pluginManager.withPlugin("java") {
-      configure { mustRunAfter(project.tasks.withType(JavaCompile::class.java)) }
+      configure { dependsOn(project.tasks.withType(JavaCompile::class.java)) }
     }
   }
 }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
@@ -15,7 +15,7 @@
  */
 package foundry.gradle.topography
 
-import foundry.common.json.regexpMapOf
+import foundry.common.buildRegexMap
 import kotlin.reflect.full.declaredMemberProperties
 
 internal object DefaultFeatures {
@@ -37,7 +37,7 @@ internal object DefaultFeatures {
       explanation =
         "The `androidTest()` feature was requested but no sources were found at `src/androidTest/**`",
       advice = "Remove `foundry.android.features.androidTest` from your build file",
-      replacementPatterns = regexpMapOf("\\bandroidTest\\(\\)".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\bandroidTest\\(\\)") },
       matchingSourcesDir = "src/androidTest",
     )
 
@@ -47,7 +47,7 @@ internal object DefaultFeatures {
       explanation =
         "The `robolectric()` feature was requested but no sources were found at `src/test/**`",
       advice = "Remove `foundry.android.features.robolectric` from your build file",
-      replacementPatterns = regexpMapOf("\\brobolectric\\(\\)".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\brobolectric\\(\\)") },
       matchingSourcesDir = "src/test",
     )
 
@@ -58,7 +58,7 @@ internal object DefaultFeatures {
         "The `compose()` feature (and thus compose-compiler) was requested but no `@Composable` annotations were found in sources",
       advice =
         "Remove `foundry.features.compose` from your build file or use `foundry.features.composeRuntimeOnly()`",
-      replacementPatterns = regexpMapOf("\\bcompose\\(\\)".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\bcompose\\(\\)") },
       matchingText = setOf("@Composable", "setContent {"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -69,7 +69,7 @@ internal object DefaultFeatures {
       explanation =
         "The `mergeComponents()` feature (and thus dagger-compiler/KAPT) was requested but no corresponding Merge*/*Component annotations were found in sources",
       advice = "Remove `foundry.features.dagger.mergeComponents` from your build file",
-      replacementPatterns = regexpMapOf("\\bmergeComponents\\(\\)".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\bmergeComponents\\(\\)") },
       matchingText =
         setOf(
           "@Component",
@@ -91,7 +91,7 @@ internal object DefaultFeatures {
       explanation =
         "The `dagger()` feature (and thus Anvil/KSP) was requested but no Dagger/Anvil annotations were found in sources",
       advice = "Remove `foundry.features.dagger` from your build file",
-      replacementPatterns = regexpMapOf("\\bdagger\\(\\)".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\bdagger\\(\\)") },
       matchingText =
         buildSet {
           addAll(DaggerCompiler.matchingText)
@@ -124,7 +124,7 @@ internal object DefaultFeatures {
         "The `moshi(codegen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
       advice = "Remove `foundry.features.moshi.codegen` from your build file",
       replacementPatterns =
-        regexpMapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
+        buildRegexMap { replace("\\bmoshi\\(codegen = true", "moshi(codegen = false") },
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -136,7 +136,8 @@ internal object DefaultFeatures {
         "The `circuit(codegen = true)` feature (and thus the KSP) was requested but no `@CircuitInject` annotations were found in sources",
       advice =
         "Remove `foundry.features.circuit.codegen` from your build file or set codegen to false (i.e. `circuit(codegen = false)`)",
-      replacementPatterns = regexpMapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
+      replacementPatterns =
+        buildRegexMap { replace("\\bcircuit\\(\\)", "circuit(codegen = false)") },
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -148,7 +149,7 @@ internal object DefaultFeatures {
         "The parcelize plugin (and thus its compiler plugin) was requested but no `@Parcelize` annotations were found in sources",
       advice = "Remove the parcelize plugin from your build file",
       replacementPatterns =
-        regexpMapOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex() to ""),
+        buildRegexMap { remove("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)") },
       matchingText = setOf("@Parcelize"),
       matchingTextFileExtensions = setOf("kt"),
       matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
@@ -161,10 +162,10 @@ internal object DefaultFeatures {
         "The KSP plugin was requested but no generated files were found in `build/generated/ksp`",
       advice = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
       replacementPatterns =
-        regexpMapOf(
-          "\\balias\\(libs\\.plugins\\.ksp\\)".toRegex() to "",
-          "\\bksp\\([a-zA-Z.-]*\\)".toRegex() to "",
-        ),
+        buildRegexMap {
+          remove("\\balias\\(libs\\.plugins\\.ksp\\)")
+          remove("\\bksp\\([a-zA-Z.-]*\\)")
+        },
       generatedSourcesDir = "build/generated/ksp",
       matchingPlugin = "com.google.devtools.ksp",
       // Don't specify extensions because KAPT can generate anything into resources
@@ -177,10 +178,10 @@ internal object DefaultFeatures {
         "The KAPT plugin was requested but no generated files were found in `build/generated/source/kapt`",
       advice = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
       replacementPatterns =
-        regexpMapOf(
-          "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)".toRegex() to "",
-          "\\bkapt\\([a-zA-Z.-]*\\)".toRegex() to "",
-        ),
+        buildRegexMap {
+          remove("\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)")
+          remove("\\bkapt\\([a-zA-Z.-]*\\)")
+        },
       generatedSourcesDir = "build/generated/source/kapt",
       matchingPlugin = "org.jetbrains.kotlin.kapt",
       // Don't specify file extensions because KSP can generate anything into resources
@@ -192,7 +193,7 @@ internal object DefaultFeatures {
       explanation =
         "Android ViewBinding was enabled but no generated viewbinding sources were found in `build/generated/data_binding_base_class_source_out`",
       advice = "Remove android.buildFeatures.viewBinding from your build file",
-      replacementPatterns = regexpMapOf("\\bviewBinding = true".toRegex() to ""),
+      replacementPatterns = buildRegexMap { remove("\\bviewBinding = true") },
       generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
       generatedSourcesExtensions = setOf("java"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
@@ -15,6 +15,7 @@
  */
 package foundry.gradle.topography
 
+import foundry.common.json.regexpMapOf
 import kotlin.reflect.full.declaredMemberProperties
 
 internal object DefaultFeatures {
@@ -36,7 +37,7 @@ internal object DefaultFeatures {
       explanation =
         "The `androidTest()` feature was requested but no sources were found at `src/androidTest/**`",
       advice = "Remove `foundry.android.features.androidTest` from your build file",
-      replacementPatterns = mapOf("\\bandroidTest\\(\\)".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\bandroidTest\\(\\)".toRegex() to ""),
       matchingSourcesDir = "src/androidTest",
     )
 
@@ -46,7 +47,7 @@ internal object DefaultFeatures {
       explanation =
         "The `robolectric()` feature was requested but no sources were found at `src/test/**`",
       advice = "Remove `foundry.android.features.robolectric` from your build file",
-      replacementPatterns = mapOf("\\brobolectric\\(\\)".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\brobolectric\\(\\)".toRegex() to ""),
       matchingSourcesDir = "src/test",
     )
 
@@ -57,7 +58,7 @@ internal object DefaultFeatures {
         "The `compose()` feature (and thus compose-compiler) was requested but no `@Composable` annotations were found in sources",
       advice =
         "Remove `foundry.features.compose` from your build file or use `foundry.features.composeRuntimeOnly()`",
-      replacementPatterns = mapOf("\\bcompose\\(\\)".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\bcompose\\(\\)".toRegex() to ""),
       matchingText = setOf("@Composable", "setContent {"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -68,7 +69,7 @@ internal object DefaultFeatures {
       explanation =
         "The `mergeComponents()` feature (and thus dagger-compiler/KAPT) was requested but no corresponding Merge*/*Component annotations were found in sources",
       advice = "Remove `foundry.features.dagger.mergeComponents` from your build file",
-      replacementPatterns = mapOf("\\bmergeComponents\\(\\)".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\bmergeComponents\\(\\)".toRegex() to ""),
       matchingText =
         setOf(
           "@Component",
@@ -90,7 +91,7 @@ internal object DefaultFeatures {
       explanation =
         "The `dagger()` feature (and thus Anvil/KSP) was requested but no Dagger/Anvil annotations were found in sources",
       advice = "Remove `foundry.features.dagger` from your build file",
-      replacementPatterns = mapOf("\\bdagger\\(\\)".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\bdagger\\(\\)".toRegex() to ""),
       matchingText =
         buildSet {
           addAll(DaggerCompiler.matchingText)
@@ -122,7 +123,8 @@ internal object DefaultFeatures {
       explanation =
         "The `moshi(codegen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
       advice = "Remove `foundry.features.moshi.codegen` from your build file",
-      replacementPatterns = mapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
+      replacementPatterns =
+        regexpMapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -134,7 +136,7 @@ internal object DefaultFeatures {
         "The `circuit(codegen = true)` feature (and thus the KSP) was requested but no `@CircuitInject` annotations were found in sources",
       advice =
         "Remove `foundry.features.circuit.codegen` from your build file or set codegen to false (i.e. `circuit(codegen = false)`)",
-      replacementPatterns = mapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
+      replacementPatterns = regexpMapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -146,7 +148,7 @@ internal object DefaultFeatures {
         "The parcelize plugin (and thus its compiler plugin) was requested but no `@Parcelize` annotations were found in sources",
       advice = "Remove the parcelize plugin from your build file",
       replacementPatterns =
-        mapOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex() to ""),
+        regexpMapOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex() to ""),
       matchingText = setOf("@Parcelize"),
       matchingTextFileExtensions = setOf("kt"),
       matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
@@ -159,7 +161,7 @@ internal object DefaultFeatures {
         "The KSP plugin was requested but no generated files were found in `build/generated/ksp`",
       advice = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
       replacementPatterns =
-        mapOf(
+        regexpMapOf(
           "\\balias\\(libs\\.plugins\\.ksp\\)".toRegex() to "",
           "\\bksp\\([a-zA-Z.-]*\\)".toRegex() to "",
         ),
@@ -175,7 +177,7 @@ internal object DefaultFeatures {
         "The KAPT plugin was requested but no generated files were found in `build/generated/source/kapt`",
       advice = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
       replacementPatterns =
-        mapOf(
+        regexpMapOf(
           "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)".toRegex() to "",
           "\\bkapt\\([a-zA-Z.-]*\\)".toRegex() to "",
         ),
@@ -190,7 +192,7 @@ internal object DefaultFeatures {
       explanation =
         "Android ViewBinding was enabled but no generated viewbinding sources were found in `build/generated/data_binding_base_class_source_out`",
       advice = "Remove android.buildFeatures.viewBinding from your build file",
-      replacementPatterns = mapOf("\\bviewBinding = true".toRegex() to ""),
+      replacementPatterns = regexpMapOf("\\bviewBinding = true".toRegex() to ""),
       generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
       generatedSourcesExtensions = setOf("java"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
@@ -122,7 +122,7 @@ internal object DefaultFeatures {
       explanation =
         "The `moshi(codegen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
       advice = "Remove `foundry.features.moshi.codegen` from your build file",
-      replacementPatterns = mapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
+      replacementPatterns = mapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -134,7 +134,7 @@ internal object DefaultFeatures {
         "The `circuit(codegen = true)` feature (and thus the KSP) was requested but no `@CircuitInject` annotations were found in sources",
       advice =
         "Remove `foundry.features.circuit.codegen` from your build file or set codegen to false (i.e. `circuit(codegen = false)`)",
-      replacementPatterns = mapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
+      replacementPatterns = mapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/DefaultFeatures.kt
@@ -36,7 +36,7 @@ internal object DefaultFeatures {
       explanation =
         "The `androidTest()` feature was requested but no sources were found at `src/androidTest/**`",
       advice = "Remove `foundry.android.features.androidTest` from your build file",
-      removalPatterns = setOf("\\bandroidTest\\(\\)".toRegex()),
+      replacementPatterns = mapOf("\\bandroidTest\\(\\)".toRegex() to ""),
       matchingSourcesDir = "src/androidTest",
     )
 
@@ -46,7 +46,7 @@ internal object DefaultFeatures {
       explanation =
         "The `robolectric()` feature was requested but no sources were found at `src/test/**`",
       advice = "Remove `foundry.android.features.robolectric` from your build file",
-      removalPatterns = setOf("\\brobolectric\\(\\)".toRegex()),
+      replacementPatterns = mapOf("\\brobolectric\\(\\)".toRegex() to ""),
       matchingSourcesDir = "src/test",
     )
 
@@ -57,7 +57,7 @@ internal object DefaultFeatures {
         "The `compose()` feature (and thus compose-compiler) was requested but no `@Composable` annotations were found in sources",
       advice =
         "Remove `foundry.features.compose` from your build file or use `foundry.features.composeRuntimeOnly()`",
-      removalPatterns = setOf("\\bcompose\\(\\)".toRegex()),
+      replacementPatterns = mapOf("\\bcompose\\(\\)".toRegex() to ""),
       matchingText = setOf("@Composable", "setContent {"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -68,7 +68,7 @@ internal object DefaultFeatures {
       explanation =
         "The `mergeComponents()` feature (and thus dagger-compiler/KAPT) was requested but no corresponding Merge*/*Component annotations were found in sources",
       advice = "Remove `foundry.features.dagger.mergeComponents` from your build file",
-      removalPatterns = setOf("\\bmergeComponents\\(\\)".toRegex()),
+      replacementPatterns = mapOf("\\bmergeComponents\\(\\)".toRegex() to ""),
       matchingText =
         setOf(
           "@Component",
@@ -90,7 +90,7 @@ internal object DefaultFeatures {
       explanation =
         "The `dagger()` feature (and thus Anvil/KSP) was requested but no Dagger/Anvil annotations were found in sources",
       advice = "Remove `foundry.features.dagger` from your build file",
-      removalPatterns = setOf("\\bdagger\\(\\)".toRegex()),
+      replacementPatterns = mapOf("\\bdagger\\(\\)".toRegex() to ""),
       matchingText =
         buildSet {
           addAll(DaggerCompiler.matchingText)
@@ -120,9 +120,9 @@ internal object DefaultFeatures {
     ModuleFeature(
       name = "moshi-codegen",
       explanation =
-        "The `moshi(codeGen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
-      advice = "Remove `foundry.features.moshi.codeGen` from your build file",
-      removalPatterns = null,
+        "The `moshi(codegen = true)` feature (and thus the moshi-ir compiler plugin) was requested but no `@JsonClass` annotations were found in sources",
+      advice = "Remove `foundry.features.moshi.codegen` from your build file",
+      replacementPatterns = mapOf("\\bcircuit\\(\\)".toRegex() to "circuit(codegen = false)"),
       matchingText = setOf("@JsonClass"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -134,7 +134,7 @@ internal object DefaultFeatures {
         "The `circuit(codegen = true)` feature (and thus the KSP) was requested but no `@CircuitInject` annotations were found in sources",
       advice =
         "Remove `foundry.features.circuit.codegen` from your build file or set codegen to false (i.e. `circuit(codegen = false)`)",
-      removalPatterns = null,
+      replacementPatterns = mapOf("\\bmoshi\\(codegen = true".toRegex() to "moshi(codegen = false"),
       matchingText = setOf("@CircuitInject"),
       matchingTextFileExtensions = setOf("kt"),
     )
@@ -145,8 +145,8 @@ internal object DefaultFeatures {
       explanation =
         "The parcelize plugin (and thus its compiler plugin) was requested but no `@Parcelize` annotations were found in sources",
       advice = "Remove the parcelize plugin from your build file",
-      removalPatterns =
-        setOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex()),
+      replacementPatterns =
+        mapOf("\\balias\\(libs\\.plugins\\.kotlin\\.plugin\\.parcelize\\)".toRegex() to ""),
       matchingText = setOf("@Parcelize"),
       matchingTextFileExtensions = setOf("kt"),
       matchingPlugin = "org.jetbrains.kotlin.plugin.parcelize",
@@ -158,8 +158,11 @@ internal object DefaultFeatures {
       explanation =
         "The KSP plugin was requested but no generated files were found in `build/generated/ksp`",
       advice = "Remove the KSP plugin (or whatever Foundry feature is requesting it)",
-      removalPatterns =
-        setOf("\\balias\\(libs\\.plugins\\.ksp\\)".toRegex(), "\\bksp\\([a-zA-Z.-]*\\)".toRegex()),
+      replacementPatterns =
+        mapOf(
+          "\\balias\\(libs\\.plugins\\.ksp\\)".toRegex() to "",
+          "\\bksp\\([a-zA-Z.-]*\\)".toRegex() to "",
+        ),
       generatedSourcesDir = "build/generated/ksp",
       matchingPlugin = "com.google.devtools.ksp",
       // Don't specify extensions because KAPT can generate anything into resources
@@ -171,10 +174,10 @@ internal object DefaultFeatures {
       explanation =
         "The KAPT plugin was requested but no generated files were found in `build/generated/source/kapt`",
       advice = "Remove the KAPT plugin (or whatever Foundry feature is requesting it)",
-      removalPatterns =
-        setOf(
-          "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)".toRegex(),
-          "\\bkapt\\([a-zA-Z.-]*\\)".toRegex(),
+      replacementPatterns =
+        mapOf(
+          "\\balias\\(libs\\.plugins\\.kotlin\\.kapt\\)".toRegex() to "",
+          "\\bkapt\\([a-zA-Z.-]*\\)".toRegex() to "",
         ),
       generatedSourcesDir = "build/generated/source/kapt",
       matchingPlugin = "org.jetbrains.kotlin.kapt",
@@ -187,7 +190,7 @@ internal object DefaultFeatures {
       explanation =
         "Android ViewBinding was enabled but no generated viewbinding sources were found in `build/generated/data_binding_base_class_source_out`",
       advice = "Remove android.buildFeatures.viewBinding from your build file",
-      removalPatterns = setOf("\\bviewBinding = true".toRegex()),
+      replacementPatterns = mapOf("\\bviewBinding = true".toRegex() to ""),
       generatedSourcesDir = "build/generated/data_binding_base_class_source_out",
       generatedSourcesExtensions = setOf("java"),
     )

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleFeature.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleFeature.kt
@@ -16,13 +16,14 @@
 package foundry.gradle.topography
 
 import com.squareup.moshi.JsonClass
+import foundry.common.json.RegexMap
 
 @JsonClass(generateAdapter = true)
 public data class ModuleFeature(
   val name: String,
   val explanation: String,
   val advice: String,
-  val replacementPatterns: Map<Regex, String> = emptyMap(),
+  val replacementPatterns: RegexMap = RegexMap(),
   /**
    * Generated sources root dir relative to the project dir, if any. Files are checked recursively.
    */

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleFeature.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleFeature.kt
@@ -22,7 +22,7 @@ public data class ModuleFeature(
   val name: String,
   val explanation: String,
   val advice: String,
-  val removalPatterns: Set<Regex>?,
+  val replacementPatterns: Map<Regex, String> = emptyMap(),
   /**
    * Generated sources root dir relative to the project dir, if any. Files are checked recursively.
    */

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -32,7 +32,7 @@ import foundry.gradle.register
 import foundry.gradle.serviceOf
 import foundry.gradle.tasks.SimpleFileProducerTask
 import foundry.gradle.tasks.SimpleFilesConsumerTask
-import foundry.gradle.tasks.mustRunAfterSourceGeneratingTasks
+import foundry.gradle.tasks.dependsOnSourceGeneratingTasks
 import foundry.gradle.tasks.publish
 import foundry.gradle.util.toJson
 import java.nio.file.Path
@@ -128,7 +128,7 @@ internal object ModuleTopographyTasks {
     // Depend on source-gen tasks
     // Don't depend on compiler tasks. Technically doesn't cover javac apt but tbh we don't really
     // support that
-    task.mustRunAfterSourceGeneratingTasks(project, includeCompilerTasks = false)
+    task.dependsOnSourceGeneratingTasks(project, includeCompilerTasks = false)
 
     // No easy way to query all plugin IDs, so we use an internal Gradle API
     val pluginRegistry = project.serviceOf<PluginRegistry>()

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -256,9 +256,9 @@ public abstract class ValidateModuleTopographyTask : DefaultTask() {
 
       val isRemoving = featuresToRemove.size != initialRemoveSize
       if (isRemoving) {
-        feature.removalPatterns?.let { removalPatterns ->
-          for (removalRegex in removalPatterns) {
-            buildFileText = buildFileText.replace(removalRegex, "").removeEmptyBraces()
+        feature.replacementPatterns.takeUnless { it.isEmpty() }?.let { replacementPatterns ->
+          for ((replacementPattern, replacement) in replacementPatterns) {
+            buildFileText = buildFileText.replace(replacementPattern, replacement).removeEmptyBraces()
           }
         }
       }
@@ -279,7 +279,7 @@ public abstract class ValidateModuleTopographyTask : DefaultTask() {
       }
     }
 
-    val allAutoFixed = featuresToRemove.all { !it.removalPatterns.isNullOrEmpty() }
+    val allAutoFixed = featuresToRemove.all { it.replacementPatterns.isNotEmpty() }
     if (featuresToRemove.isNotEmpty()) {
       val message = buildString {
         appendLine(

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/topography/ModuleTopographyTask.kt
@@ -256,11 +256,14 @@ public abstract class ValidateModuleTopographyTask : DefaultTask() {
 
       val isRemoving = featuresToRemove.size != initialRemoveSize
       if (isRemoving) {
-        feature.replacementPatterns.takeUnless { it.isEmpty() }?.let { replacementPatterns ->
-          for ((replacementPattern, replacement) in replacementPatterns) {
-            buildFileText = buildFileText.replace(replacementPattern, replacement).removeEmptyBraces()
+        feature.replacementPatterns
+          .takeUnless { it.isEmpty() }
+          ?.let { replacementPatterns ->
+            for ((replacementPattern, replacement) in replacementPatterns) {
+              buildFileText =
+                buildFileText.replace(replacementPattern, replacement).removeEmptyBraces()
+            }
           }
-        }
       }
     }
 

--- a/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
+++ b/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
@@ -31,6 +31,7 @@ public class RegexMap internal constructor(delegate: Map<Regex, String>) :
 public fun buildRegexMap(body: RegexMapBuilder.() -> Unit): RegexMap =
   RegexMap(RegexMapBuilderImpl().apply(body).map)
 
+// Kate comment on this so I know you've read it! :P
 public interface RegexMapBuilder {
   public fun remove(@Language("RegExp") regex: String): Unit = replace(regex, "")
 

--- a/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
+++ b/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
@@ -1,0 +1,31 @@
+package foundry.common
+
+import java.util.TreeMap
+import org.intellij.lang.annotations.Language
+
+/**
+ * A [Map] that can have [Regex] keys. This requires a custom impl because [Regex] is not
+ * comparable, so we internally back these with a [TreeMap] rather than the conventional
+ * [LinkedHashMap].
+ */
+public class RegexMap internal constructor(delegate: Map<Regex, String>) :
+  Map<Regex, String> by delegate {
+  public constructor() : this(emptyMap())
+}
+
+public fun buildRegexMap(body: RegexMapBuilder.() -> Unit): RegexMap =
+  RegexMap(RegexMapBuilderImpl().apply(body).map)
+
+public interface RegexMapBuilder {
+  public fun remove(@Language("RegExp") regex: String): Unit = replace(regex, "")
+
+  public fun replace(@Language("RegExp") regex: String, replacement: String)
+}
+
+private class RegexMapBuilderImpl : RegexMapBuilder {
+  val map = TreeMap<Regex, String>(compareBy { it.pattern })
+
+  override fun replace(regex: String, replacement: String) {
+    map.put(regex.toRegex(), replacement)
+  }
+}

--- a/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
+++ b/tools/foundry-common/src/main/kotlin/foundry/common/RegexMap.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2024 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foundry.common
 
 import java.util.TreeMap

--- a/tools/foundry-common/src/main/kotlin/foundry/common/json/JsonTools.kt
+++ b/tools/foundry-common/src/main/kotlin/foundry/common/json/JsonTools.kt
@@ -23,12 +23,6 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import com.squareup.moshi.addAdapter
 import com.squareup.moshi.rawType
-import okio.Buffer
-import okio.BufferedSink
-import okio.BufferedSource
-import okio.buffer
-import okio.sink
-import okio.source
 import java.io.File
 import java.lang.reflect.Type
 import java.nio.file.Path
@@ -36,6 +30,12 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.TreeMap
+import okio.Buffer
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.buffer
+import okio.sink
+import okio.source
 
 public object JsonTools {
   public val MOSHI: Moshi =
@@ -149,6 +149,9 @@ private class RegexJsonAdapter : JsonAdapter<Regex>() {
 /** A [MutableMap] that can have [Regex] keys. */
 public class RegexMap() :
   MutableMap<Regex, String> by TreeMap<Regex, String>(compareBy { it.pattern })
+
+public fun regexpMapOf(vararg entries: Pair<Regex, String>): RegexMap =
+  RegexMap().apply { putAll(entries.toMap()) }
 
 private class RegexMapJsonAdapter(private val stringAdapter: JsonAdapter<String>) :
   JsonAdapter<RegexMap>() {


### PR DESCRIPTION
- Fix source-generating tasks to use dependsOn again because otherwise they may not run when we actually want
- Replace `removalPatterns` with a more flexible `replacementPatterns`

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->