### PR TITLE
Add blank behavior controls to PropertyResolver.optionalStringProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
-- Add blank behavior parameters to `PropertyResolver.optionalStringProvider` overloads to specify behavior for blank property values. Default behavior now is to error. 
+- Add blank behavior parameters to `PropertyResolver.optionalStringProvider` overloads to specify behavior for blank property values. Default behavior now is to error.
 
 0.23.2
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- Add blank behavior parameters to `PropertyResolver.optionalStringProvider` overloads to specify behavior for blank property values. Default behavior now is to error. 
+
 0.23.2
 ------
 

--- a/platforms/gradle/better-gradle-properties/api/better-gradle-properties.api
+++ b/platforms/gradle/better-gradle-properties/api/better-gradle-properties.api
@@ -42,14 +42,24 @@ public final class foundry/gradle/properties/PropertyResolver {
 	public final fun intValue (Ljava/lang/String;I)I
 	public final fun intValue (Ljava/lang/String;Lorg/gradle/api/provider/Provider;)I
 	public static synthetic fun intValue$default (Lfoundry/gradle/properties/PropertyResolver;Ljava/lang/String;IILjava/lang/Object;)I
-	public final fun optionalStringProvider (Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
-	public final fun optionalStringProvider (Ljava/lang/String;Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
-	public static synthetic fun optionalStringProvider$default (Lfoundry/gradle/properties/PropertyResolver;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
+	public final fun optionalStringProvider (Ljava/lang/String;Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;)Lorg/gradle/api/provider/Provider;
+	public final fun optionalStringProvider (Ljava/lang/String;Ljava/lang/String;Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;)Lorg/gradle/api/provider/Provider;
+	public static synthetic fun optionalStringProvider$default (Lfoundry/gradle/properties/PropertyResolver;Ljava/lang/String;Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
+	public static synthetic fun optionalStringProvider$default (Lfoundry/gradle/properties/PropertyResolver;Ljava/lang/String;Ljava/lang/String;Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;ILjava/lang/Object;)Lorg/gradle/api/provider/Provider;
 	public final fun optionalStringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun optionalStringValue$default (Lfoundry/gradle/properties/PropertyResolver;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 	public final fun providerFor (Ljava/lang/String;)Lorg/gradle/api/provider/Provider;
 	public final fun stringValue (Ljava/lang/String;)Ljava/lang/String;
 	public final fun stringValue (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class foundry/gradle/properties/PropertyResolver$BlankBehavior : java/lang/Enum {
+	public static final field ERROR Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;
+	public static final field FILTER Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;
+	public static final field NONE Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;
+	public static fun values ()[Lfoundry/gradle/properties/PropertyResolver$BlankBehavior;
 }
 
 public final class foundry/gradle/properties/PropertyResolver$Companion {


### PR DESCRIPTION
This helps avoid subtle bugs with blank providers

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->