### PR TITLE
Add orchestrator dep when androidTest is enabled

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -510,7 +510,9 @@ internal class StandardProjectConfigurations(
                 .getOrElse(false)
           val isAndroidTestEnabled = variant is HasAndroidTest && variant.androidTest != null
           if (isAndroidTestEnabled) {
-            dependencies.add("androidTestUtil", "androidx.test:orchestrator")
+            if (foundryProperties.useOrchestrator.getOrElse(false)) {
+              dependencies.add("androidTestUtil", "androidx.test:orchestrator")
+            }
             if (!excluded && isAffectedProject) {
               // Aggregate test apks. In Fladle we aggregate test APKs, in emulator.wtf we aggregate
               // to their root project dep

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -510,7 +510,7 @@ internal class StandardProjectConfigurations(
                 .getOrElse(false)
           val isAndroidTestEnabled = variant is HasAndroidTest && variant.androidTest != null
           if (isAndroidTestEnabled) {
-            dependencies.add("androidTestUtil", libs.androidx.testing.orchestrator)
+            dependencies.add("androidTestUtil", "androidx.test:orchestrator")
             if (!excluded && isAffectedProject) {
               // Aggregate test apks. In Fladle we aggregate test APKs, in emulator.wtf we aggregate
               // to their root project dep

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -510,6 +510,7 @@ internal class StandardProjectConfigurations(
                 .getOrElse(false)
           val isAndroidTestEnabled = variant is HasAndroidTest && variant.androidTest != null
           if (isAndroidTestEnabled) {
+            dependencies.add("androidTestUtil", libs.androidx.testing.orchestrator)
             if (!excluded && isAffectedProject) {
               // Aggregate test apks. In Fladle we aggregate test APKs, in emulator.wtf we aggregate
               // to their root project dep


### PR DESCRIPTION
This is needed in order to run instrumentation tests locally.