### PR TITLE
Gate dagger processing options behind a property instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- Gate Dagger's processing options on a new `foundry.dagger.options` property. The structure of this is a comma-separated list of key=value pairs. i.e. `foundry.dagger.options=dagger.useBindingGraphFix=ENABLED,dagger.ignoreProvisionKeyWildcards=ENABLED`.
+
 0.24.0
 ------
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
@@ -727,6 +727,19 @@ internal constructor(
         AnvilMode.valueOf(it.uppercase(Locale.US))
       }
 
+  /**
+   * Defines Dagger processing options. The structure of this is a comma-separated list of key=value
+   * pairs. i.e.
+   *
+   * `foundry.dagger.options=dagger.useBindingGraphFix=ENABLED,dagger.ignoreProvisionKeyWildcards=ENABLED`
+   */
+  public val daggerOptions: Provider<Map<String, String>>
+    get() =
+      resolver.optionalStringProvider("foundry.dagger.options", defaultValue = "").map { value ->
+        if (value.isBlank()) return@map emptyMap<String, String>()
+        value.splitToSequence(',').associate { kv -> kv.trim().split('=').let { it[0] to it[1] } }
+      }
+
   /** Overrides the kotlin language version if present. */
   public val kaptLanguageVersion: Provider<KotlinVersion>
     get() =


### PR DESCRIPTION
This way these can be controlled repo-side

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->