### PR TITLE
Make --android-test-project-paths optional in Skippy

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
@@ -153,7 +153,6 @@ internal abstract class BasicAptOptionsConfig : AptOptionsConfig {
           configure<KaptExtension> {
             arguments {
               baseConfig.globalOptions(foundryProperties).forEach { (key, value) ->
-                logger.lifecycle("Adding kapt args to $path: $key=$value")
                 arg(key, value)
               }
             }

--- a/tools/skippy/src/main/kotlin/foundry/skippy/ComputeAffectedProjectsCli.kt
+++ b/tools/skippy/src/main/kotlin/foundry/skippy/ComputeAffectedProjectsCli.kt
@@ -95,7 +95,6 @@ public class ComputeAffectedProjectsCli : SuspendingCliktCommand() {
           "Path to a file that contains a newline-delimited list of project paths that produce androidTest APKs.",
       )
       .path(mustExist = true, canBeDir = false, mustBeReadable = true)
-      .required()
 
   private val logger = FoundryLogger.clikt(this)
 
@@ -113,7 +112,7 @@ public class ComputeAffectedProjectsCli : SuspendingCliktCommand() {
       } else {
         1
       }
-    val androidTestProjects = androidTestProjectPaths.readLines().toSet()
+    val androidTestProjects = androidTestProjectPaths?.readLines().orEmpty().toSet()
     val body: suspend (context: CoroutineContext) -> Unit = { context ->
       SkippyRunner(
           debug = debug,


### PR DESCRIPTION
It's not actually required!

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->