### PR TITLE
Using JCEFHtmlPanelProvider for Skate "What's New"

### DIFF
--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/SkateService.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/SkateService.kt
@@ -18,6 +18,7 @@ package foundry.intellij.skate
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
@@ -63,7 +64,11 @@ class SkateProjectServiceImpl(private val project: Project) : SkateProjectServic
           anchor = ToolWindowAnchor.RIGHT
         }
 
-      WhatsNewPanelFactory().createToolWindowContent(toolWindow, project, parsedChangelog)
+      // The Disposable is necessary to prevent a substantial memory leak while working with
+      // MarkdownJCEFHtmlPanel
+      val parentDisposable = Disposer.newDisposable()
+      WhatsNewPanelFactory()
+        .createToolWindowContent(toolWindow, project, parsedChangelog, parentDisposable)
 
       toolWindow.show()
     }

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/ui/WhatsNewPanelFactory.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/ui/WhatsNewPanelFactory.kt
@@ -49,7 +49,7 @@ class WhatsNewPanelFactory : DumbAware {
     changeLogContent: ChangelogParser.PresentedChangelog,
     parentDisposable: Disposable,
   ) {
-    val toolWindowContent = WhatsNewPanelContent(project, changeLogContent)
+    val toolWindowContent = WhatsNewPanelContent(project, changeLogContent, parentDisposable)
     val content =
       ContentFactory.getInstance().createContent(toolWindowContent.contentPanel, "", false)
     toolWindow.contentManager.addContent(content)
@@ -69,6 +69,7 @@ class WhatsNewPanelFactory : DumbAware {
     changeLogContent: ChangelogParser.PresentedChangelog,
     parentDisposable: Disposable,
   ) {
+    private val logger = logger<WhatsNewPanelContent>()
     // Actual panel box for "What's New in Slack!"
     val contentPanel = createWhatsNewPanel(project, changeLogContent, parentDisposable)
 


### PR DESCRIPTION
Due to recent support of Markdown support on Android Studio, we are able to re-instate this for the Skate "What's New" panel.

Developers were having issues with the panel's rendering, specifically how it became transparent. 

Testing locally with building the plugin from main and from the branch, the markdown seems to be fixed:
<p align="center">
  <img src="https://github.com/user-attachments/assets/a36f9b00-c55c-477a-a438-e40ee14a33ff" width="45%" />
  <img src="https://github.com/user-attachments/assets/5c5abd1c-5858-4d12-99fc-9443c2eb89be" width="45%" style="height: 90%;" />
</p>

Here is the issue tracker for Markdown support on Android Studio: https://issuetracker.google.com/issues/159933628#comment19

UPDATE: unfortunately doesn't work out of the box because I had to follow the instructions on comment 19 from this link, and it doesn't work without it. 
```
Based on #7

TLDR for https://intellij-support.jetbrains.com/hc/en-us/articles/206544879-Selecting-the-JDK-version-the-IDE-will-run-under:

In the Android Studio:

Find action (ctrl + shift + A / command + shift + A)
Search for Choose Boot Java Runtime for the IDE
Select the latest version in the "New:" dropdown - e.g. 11.0.12+7-b1504.27 JetBrains Runtime with JCEF
OK
Restart
Worked in: Android Studio Chipmunk | 2021.2.1 Patch 1 | Build #AI-212.5712.43.2112.8609683
```

To reproduce both images:
- on main, I ran `./gradlew buildPlugin`, and downloaded the `skate.zip` file from `skate/build/distributions`.
- installed that zip plugin from disk on `Ladybug Feature Drop | 2024.2.2`
- changed the dates in "WHATSNEW.md" to trigger the panel
- I then repeated the same steps but ran buildPlugin from this branch.

Slack discussion: https://slack-pde.slack.com/archives/C8DPL9DBJ/p1740587910092529