### PR TITLE
Allow Android Studio to run with Skate with runLocalIde

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,6 +39,9 @@ ksp.useKSP2=true
 # https://github.com/JetBrains/intellij-platform-gradle-plugin/blob/33af9bdd1d0d8b996b911781ab23013dd14997f4/src/main/kotlin/org/jetbrains/intellij/platform/gradle/GradleProperties.kt#L104C12-L104C27
 org.jetbrains.intellij.platform.SelfUpdateCheck=false
 
+# We can now run ./gradlew runLocalIde on Android Studio, so we have test more comprehensively with Skate
+intellijPlatformTesting.idePath=/Applications/Android Studio.app/Contents
+
 # Versioning bits
 GROUP=com.slack.foundry
 POM_URL=https://github.com/slackhq/foundry/

--- a/platforms/intellij/skate/build.gradle.kts
+++ b/platforms/intellij/skate/build.gradle.kts
@@ -39,13 +39,6 @@ intellijPlatform {
       email = "oss@slack-corp.com"
     }
   }
-  val runLocalIde by
-    intellijPlatformTesting.runIde.registering {
-      // https://plugins.jetbrains.com/docs/intellij/android-studio.html#configuring-the-plugin-gradle-build-script
-      providers.gradleProperty("intellijPlatformTesting.idePath").orNull?.let {
-        localPath.set(file(it))
-      }
-    }
 }
 
 fun isGitHash(hash: String): Boolean {
@@ -142,6 +135,14 @@ dependencies {
 
     testFramework(TestFrameworkType.Platform)
     testFramework(TestFrameworkType.Bundled)
+
+    val runLocalIde by
+      intellijPlatformTesting.runIde.registering {
+        // https://plugins.jetbrains.com/docs/intellij/android-studio.html#configuring-the-plugin-gradle-build-script
+        providers.gradleProperty("intellijPlatformTesting.idePath").orNull?.let {
+          localPath.set(file(it))
+        }
+      }
   }
 
   implementation(projects.platforms.intellij.compose, exclusions)

--- a/platforms/intellij/skate/build.gradle.kts
+++ b/platforms/intellij/skate/build.gradle.kts
@@ -39,6 +39,13 @@ intellijPlatform {
       email = "oss@slack-corp.com"
     }
   }
+  val runLocalIde by
+    intellijPlatformTesting.runIde.registering {
+      // https://plugins.jetbrains.com/docs/intellij/android-studio.html#configuring-the-plugin-gradle-build-script
+      providers.gradleProperty("intellijPlatformTesting.idePath").orNull?.let {
+        localPath.set(file(it))
+      }
+    }
 }
 
 fun isGitHash(hash: String): Boolean {


### PR DESCRIPTION
Currently, running `./gradlew :platforms:intellij:skate:runIde` opens up a new instance of IntelliJ to test the plugin. 

Because some things like Markdown rendering are different in Android Studio and IntelliJ, I set up a way to run AS locally. This will save time so we don't have to build the plugin and install the zip on AS to test our Skate changes.

