### PR TITLE
Add support for Java agent configuration in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **New**: Add a `dependencies.testJavaAgents { ... }` API for configuring Java agents that need to run in tests, such as Mockito in future versions of Java.
+
 0.25.4
 ------
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/Aliases.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/Aliases.kt
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import foundry.gradle.AndroidHandler
-import foundry.gradle.FoundryExtension
 import foundry.gradle.FoundryAndroidAppExtension
 import foundry.gradle.FoundryAndroidLibraryExtension
+import foundry.gradle.FoundryExtension
 import foundry.gradle.findByType
 import org.gradle.api.Action
 import org.gradle.api.Project

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
@@ -168,7 +168,7 @@ internal fun Project.getVersionsCatalog(name: String = "libs"): VersionCatalog {
 internal fun Project.getVersionsCatalogOrNull(name: String = "libs"): VersionCatalog? {
   return try {
     project.extensions.getByType<VersionCatalogsExtension>().named(name)
-  } catch (ignored: Exception) {
+  } catch (_: Exception) {
     null
   }
 }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryVersions.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryVersions.kt
@@ -111,6 +111,9 @@ internal class FoundryVersions(
   val emulatorWtf: Optional<String>
     get() = getOptionalValue("emulatorWtf")
 
+  val mockito: Optional<String>
+    get() = getOptionalValue("mockito")
+
   fun lookupVersion(key: String) = getOptionalValue(key)
 
   class Bundles(

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/testing/UnitTests.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/testing/UnitTests.kt
@@ -29,6 +29,7 @@ import foundry.gradle.properties.synchronousEnvProperty
 import foundry.gradle.tasks.SimpleFileProducerTask
 import foundry.gradle.tasks.SimpleFilesConsumerTask
 import foundry.gradle.tasks.publish
+import foundry.gradle.util.JavaAgentDependenciesExtension
 import kotlin.math.max
 import kotlin.math.roundToInt
 import org.gradle.api.Project
@@ -85,6 +86,8 @@ internal object UnitTests {
     affectedProjects: Set<String>?,
     onProjectSkipped: (String, String) -> Unit,
   ) {
+    JavaAgentDependenciesExtension.register(project, foundryProperties)
+
     // Projects can opt out of creating the task with this property.
     // android test projects don't support unit tests
     val enabled = foundryProperties.ciUnitTestEnabled && pluginId != "com.android.test"

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentArgumentProvider.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentArgumentProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.gradle.util
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Classpath
+import org.gradle.process.CommandLineArgumentProvider
+
+internal abstract class JavaAgentArgumentProvider : CommandLineArgumentProvider {
+  @get:Classpath abstract val classpath: ConfigurableFileCollection
+
+  override fun asArguments() = listOf("-javaagent:${classpath.singleFile.absolutePath}")
+}

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
@@ -54,7 +54,9 @@ constructor(private val project: Project, private val foundryProperties: Foundry
       project.configurations.detachedConfiguration(dependency).apply { isTransitive = false }
     project.tasks.withType(Test::class.java) {
       jvmArgumentProviders.add(
-        project.objects.newInstance<JavaAgentArgumentProvider>().apply { classpath.from(config) }
+        project.objects.newInstance<JavaAgentArgumentProvider>().apply {
+          classpath.from(project.files(config))
+        }
       )
     }
   }

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.gradle.util
+
+import foundry.gradle.FoundryProperties
+import foundry.gradle.newInstance
+import javax.inject.Inject
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.tasks.testing.Test
+
+/**
+ * An extension that simplifies dependency configuration for (test) Java agents in Gradle projects.
+ *
+ * Provides utilities for managing Java agent dependencies during test execution and automatically
+ * configuring necessary JVM arguments.
+ *
+ * Example usage in build.gradle.kts:
+ * ```
+ * dependencies {
+ *   testJavaAgents {
+ *     mockitoAgent() // Deprecated, please don't use Mockito
+ *     javaAgent("com.example:custom-java-agent:1.0.0")
+ *   }
+ * }
+ * ```
+ */
+public abstract class JavaAgentDependenciesExtension
+@Inject
+constructor(private val project: Project, private val foundryProperties: FoundryProperties) {
+
+  @Deprecated("Don't use mockito for new tests.")
+  public fun DependencyHandler.mockitoAgent() {
+    foundryProperties.versions.mockito.ifPresent { javaAgent("org.mockito:mockito-core:$it") }
+  }
+
+  public fun DependencyHandler.javaAgent(dependencyNotation: Any) {
+    val dependency = project.dependencies.create(dependencyNotation)
+    add("testImplementation", dependency)
+    val config =
+      project.configurations.detachedConfiguration(dependency).apply { isTransitive = false }
+    project.tasks.withType(Test::class.java) {
+      jvmArgumentProviders.add(
+        project.objects.newInstance<JavaAgentArgumentProvider>().apply { classpath.from(config) }
+      )
+    }
+  }
+
+  internal companion object {
+    fun register(project: Project, foundryProperties: FoundryProperties) =
+      project.dependencies.extensions.create<JavaAgentDependenciesExtension>(
+        /* name = */ "testJavaAgents",
+        /* type = */ JavaAgentDependenciesExtension::class.java,
+        /* ...constructionArguments = */ project,
+        foundryProperties,
+      )
+  }
+}

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
@@ -52,7 +52,7 @@ constructor(private val project: Project, private val foundryProperties: Foundry
     add("testImplementation", dependency)
     val config =
       project.configurations.detachedConfiguration(dependency).apply { isTransitive = false }
-    project.tasks.withType(Test::class.java) {
+    project.tasks.withType(Test::class.java).configureEach {
       jvmArgumentProviders.add(
         project.objects.newInstance<JavaAgentArgumentProvider>().apply {
           classpath.from(config.incoming.artifactView {}.files)

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/util/JavaAgentDependenciesExtension.kt
@@ -55,7 +55,7 @@ constructor(private val project: Project, private val foundryProperties: Foundry
     project.tasks.withType(Test::class.java) {
       jvmArgumentProviders.add(
         project.objects.newInstance<JavaAgentArgumentProvider>().apply {
-          classpath.from(project.files(config))
+          classpath.from(config.incoming.artifactView {}.files)
         }
       )
     }


### PR DESCRIPTION
Introduce a new `testJavaAgents` API for simplifying the configuration of Java agents in test environments. The basic entry point is

```kotlin
dependencies {
  testJavaAgents {
    javaAgent(...)
  }
}
```

With a convenience (deprecated) `mockitoAgent()` (which is what spurred this)

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->