### PR TITLE
Add gradle path copy actions to Skate

### DIFF
--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/CopyGradleProjectAccessorPathProvider.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/CopyGradleProjectAccessorPathProvider.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.intellij.skate.gradle
+
+import com.intellij.ide.actions.DumbAwareCopyPathProvider
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Action to copy the Gradle project accessor path in the format "projects.path.to.project". If the
+ * selected file is not a Gradle project directory, it will find the nearest parent Gradle project.
+ */
+class CopyGradleProjectAccessorPathProvider : DumbAwareCopyPathProvider() {
+
+  override fun getPathToElement(
+    project: Project,
+    virtualFile: VirtualFile?,
+    editor: Editor?,
+  ): String? {
+    if (virtualFile == null) return null
+
+    val vcsRoot = ProjectLevelVcsManager.getInstance(project).getVcsRootObjectFor(virtualFile)
+    if (vcsRoot == null) return null
+
+    // Find the nearest Gradle project directory
+    val gradleProjectDir =
+      GradleProjectUtils.findNearestGradleProject(vcsRoot.path, virtualFile) ?: return null
+
+    // Get the Gradle project accessor path
+    val gradleProjectAccessorPath =
+      GradleProjectUtils.getGradleProjectAccessorPath(project, gradleProjectDir) ?: return null
+
+    return gradleProjectAccessorPath
+  }
+}

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/CopyGradleProjectPathProvider.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/CopyGradleProjectPathProvider.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.intellij.skate.gradle
+
+import com.intellij.ide.actions.DumbAwareCopyPathProvider
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vcs.ProjectLevelVcsManager
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Action to copy the Gradle project path in the format ":path:to:project". If the selected file is
+ * not a Gradle project directory, it will find the nearest parent Gradle project.
+ */
+class CopyGradleProjectPathProvider : DumbAwareCopyPathProvider() {
+
+  override fun getPathToElement(
+    project: Project,
+    virtualFile: VirtualFile?,
+    editor: Editor?,
+  ): String? {
+    if (virtualFile == null) return null
+
+    val vcsRoot = ProjectLevelVcsManager.getInstance(project).getVcsRootObjectFor(virtualFile)
+    if (vcsRoot == null) return null
+
+    // Find the nearest Gradle project directory
+    val gradleProjectDir =
+      GradleProjectUtils.findNearestGradleProject(vcsRoot.path, virtualFile) ?: return null
+
+    // Get the Gradle project path
+    return GradleProjectUtils.getGradleProjectPath(project, gradleProjectDir)
+  }
+}

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/GradleProjectUtils.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/gradle/GradleProjectUtils.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.intellij.skate.gradle
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import java.nio.file.Paths
+
+/** Utility functions for working with Gradle projects. */
+object GradleProjectUtils {
+
+  /**
+   * Checks if the given directory is a Gradle project by looking for build.gradle or
+   * build.gradle.kts files.
+   */
+  fun isGradleProject(directory: VirtualFile): Boolean {
+    if (!directory.isDirectory) return false
+    return directory.children.any { it.name == "build.gradle" || it.name == "build.gradle.kts" }
+  }
+
+  /**
+   * Finds the nearest parent Gradle project directory for the given file or directory. Returns the
+   * file itself if it's a Gradle project directory, or null if no Gradle project is found.
+   */
+  fun findNearestGradleProject(root: VirtualFile, file: VirtualFile): VirtualFile? {
+    var current: VirtualFile? = file
+    while (current != null) {
+      if (isGradleProject(current)) {
+        return current
+      } else if (current == root) {
+        return null
+      }
+      current = current.parent
+    }
+    return null
+  }
+
+  /**
+   * Gets the Gradle project path for the given directory in the format ":path:to:project". Returns
+   * null if the directory is not part of a Gradle project.
+   */
+  fun getGradleProjectPath(project: Project, directory: VirtualFile): String? {
+    @Suppress("DEPRECATION") val projectBasePath = project.baseDir.path
+    val projectBaseDir = Paths.get(projectBasePath)
+    val directoryPath = Paths.get(directory.path)
+
+    // Check if the directory is within the project
+    if (!directoryPath.startsWith(projectBaseDir)) {
+      return null
+    }
+
+    // Get the relative path from the project base directory
+    val relativePath = projectBaseDir.relativize(directoryPath)
+    if (relativePath.toString().isEmpty()) {
+      return ":"
+    }
+
+    // Convert the path to Gradle format
+    return ":" + relativePath.toString().replace('/', ':')
+  }
+
+  /**
+   * Gets the Gradle project accessor path for the given directory in the format
+   * "projects.path.to.project". Returns null if the directory is not part of a Gradle project or
+   * the root project
+   */
+  fun getGradleProjectAccessorPath(project: Project, directory: VirtualFile): String? {
+    val gradlePath = getGradleProjectPath(project, directory) ?: return null
+    if (gradlePath == ":") {
+      return null
+    }
+
+    // Convert from ":path:to:project" to "projects.path.to.project"
+    return "projects" + gradlePath.replace(':', '.')
+  }
+}

--- a/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
+++ b/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,18 @@
             <add-to-group group-id="ToolbarRunGroup" anchor="last"/>
             <add-to-group group-id="NavBarToolBar" anchor="last"/>
         </action>
+        <action id="foundry.intellij.skate.gradle.CopyGradleProjectPathProvider"
+                class="foundry.intellij.skate.gradle.CopyGradleProjectPathProvider"
+                text="Gradle Project Path"
+                description="Copy the Gradle project path in the format ':path:to:project'">
+            <add-to-group group-id="CopyFileReference" anchor="last"/>
+        </action>
+        <action id="foundry.intellij.skate.gradle.CopyGradleProjectAccessorPathProvider"
+                class="foundry.intellij.skate.gradle.CopyGradleProjectAccessorPathProvider"
+                text="Gradle Project Accessor Path"
+                description="Copy the Gradle project accessor path in the format 'projects.path.to.project'">
+            <add-to-group group-id="CopyFileReference" anchor="last"/>
+        </action>
     </actions>
 
 </idea-plugin>

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/gradle/GradleProjectUtilsTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/gradle/GradleProjectUtilsTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.intellij.skate.gradle
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.mock.MockProject
+import com.intellij.mock.MockVirtualFile
+import com.intellij.openapi.util.Disposer
+import org.junit.Test
+
+class GradleProjectUtilsTest {
+
+  @Test
+  fun `findNearestGradleProject returns current directory if it is a Gradle project`() {
+    val root = MockVirtualFile(true, "root")
+    val gradleDir = MockVirtualFile(true, "gradleProject")
+    gradleDir.addChild(MockVirtualFile(false, "build.gradle"))
+    root.addChild(gradleDir)
+
+    assertThat(GradleProjectUtils.findNearestGradleProject(root, gradleDir)).isEqualTo(gradleDir)
+  }
+
+  @Test
+  fun `findNearestGradleProject returns nearest parent Gradle project`() {
+    val root = MockVirtualFile(true, "root")
+    val gradleDir = MockVirtualFile(true, "gradleProject")
+    gradleDir.addChild(MockVirtualFile(false, "build.gradle"))
+    val subDir = MockVirtualFile(true, "subDir")
+    gradleDir.addChild(subDir)
+    root.addChild(gradleDir)
+
+    assertThat(GradleProjectUtils.findNearestGradleProject(root, subDir)).isEqualTo(gradleDir)
+  }
+
+  @Test
+  fun `findNearestGradleProject returns null if no Gradle project is found`() {
+    val root = MockVirtualFile(true, "root")
+    val subDir = MockVirtualFile(true, "subDir")
+    subDir.addChild(MockVirtualFile(false, "someFile.txt"))
+    root.addChild(subDir)
+
+    assertThat(GradleProjectUtils.findNearestGradleProject(root, subDir)).isNull()
+  }
+
+  @Test
+  fun `findNearestGradleProject returns root if it is a Gradle project`() {
+    val root = MockVirtualFile(true, "root")
+    root.addChild(MockVirtualFile(false, "build.gradle"))
+    val subDir = MockVirtualFile(true, "subDir")
+    root.addChild(subDir)
+
+    assertThat(GradleProjectUtils.findNearestGradleProject(root, subDir)).isEqualTo(root)
+  }
+
+  @Test
+  fun `isGradleProject returns true when directory contains build_gradle`() {
+    val exampleDir = MockVirtualFile(true, "exampleDir")
+    exampleDir.addChild(MockVirtualFile(false, "build.gradle"))
+    exampleDir.addChild(MockVirtualFile(false, "other_file.txt"))
+
+    assertThat(GradleProjectUtils.isGradleProject(exampleDir)).isTrue()
+  }
+
+  @Test
+  fun `isGradleProject returns true when directory contains build_gradle_kts`() {
+    val exampleDir = MockVirtualFile(true, "exampleDir")
+    exampleDir.addChild(MockVirtualFile(false, "build.gradle.kts"))
+    exampleDir.addChild(MockVirtualFile(false, "some_file.txt"))
+
+    assertThat(GradleProjectUtils.isGradleProject(exampleDir)).isTrue()
+  }
+
+  @Test
+  fun `isGradleProject returns false for directory with no gradle build files`() {
+    val exampleDir = MockVirtualFile(true, "exampleDir")
+    exampleDir.addChild(MockVirtualFile(false, "file1.txt"))
+    exampleDir.addChild(MockVirtualFile(false, "file2.doc"))
+
+    assertThat(GradleProjectUtils.isGradleProject(exampleDir)).isFalse()
+  }
+
+  @Test
+  fun `isGradleProject returns false when VirtualFile is not a directory`() {
+    val exampleFile = MockVirtualFile(false, "exampleFile")
+
+    assertThat(GradleProjectUtils.isGradleProject(exampleFile)).isFalse()
+  }
+
+  @Test
+  fun `isGradleProject returns false when directory has no children`() {
+    val exampleDir = MockVirtualFile(true, "exampleDir")
+
+    assertThat(GradleProjectUtils.isGradleProject(exampleDir)).isFalse()
+  }
+
+  @Test
+  fun `getGradleProjectPath returns root path when base path matches directory`() {
+    val rootDir = MockVirtualFile(true, "rootDir")
+    val project = MockProject(null, Disposer.newDisposable()).apply { baseDir = rootDir }
+
+    val directory = MockVirtualFile(true, "rootDir")
+
+    assertThat(GradleProjectUtils.getGradleProjectPath(project, directory)).isEqualTo(":")
+  }
+
+  @Test
+  fun `getGradleProjectPath returns correct path for nested directory`() {
+    val rootDir = MockVirtualFile(true, "rootDir")
+    val project = MockProject(null, Disposer.newDisposable()).apply { baseDir = rootDir }
+
+    val nestedDir = MockVirtualFile(true, "nested")
+    val projectDir = MockVirtualFile(true, "project")
+    nestedDir.addChild(projectDir)
+    rootDir.addChild(nestedDir)
+
+    assertThat(GradleProjectUtils.getGradleProjectPath(project, projectDir))
+      .isEqualTo(":nested:project")
+  }
+
+  @Test
+  fun `getGradleProjectPath returns null for directory outside project base path`() {
+    val rootDir = MockVirtualFile(true, "rootDir")
+    val project = MockProject(null, Disposer.newDisposable()).apply { baseDir = rootDir }
+
+    val externalDirectory = MockVirtualFile(true, "externalDirectory")
+
+    assertThat(GradleProjectUtils.getGradleProjectPath(project, externalDirectory)).isNull()
+  }
+}


### PR DESCRIPTION
Resolves #1049

Took some inspo from IntelliJ's https://github.com/JetBrains/intellij-community/blob/d964c13ab2050a89bba5b6be5dea15d0352c1268/plugins/git4idea/src/git4idea/actions/CopyRepositoryRootPathProvider.kt#L11

![image](https://github.com/user-attachments/assets/5d2c2006-c2a5-46a9-803a-37f11e3dea33)


<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->