### PR TITLE
Remove old compose workarounds

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
@@ -209,32 +209,6 @@ internal constructor(
       resolver.providerFor("foundry.compose.stabilityConfigurationPath").map(regularFileProvider)
 
   /**
-   * Use a workaround for compose-compiler's `includeInformation` option on android projects.
-   *
-   * On android projects, the compose compiler gradle plugin annoyingly no-ops
-   *
-   * @see <a href="https://issuetracker.google.com/issues/362780328#comment4">Upstream issue</a>
-   */
-  public val composeUseIncludeInformationWorkaround: Boolean
-    get() =
-      resolver.booleanValue("foundry.compose.useIncludeInformationWorkaround", defaultValue = true)
-
-  /**
-   * By default, Compose on android only enables source information in debug variants. This is a bit
-   * silly in large projects because we generally make all libraries single-variant as "release",
-   * and can result in libraries not having source information. Instead, we rely on R8 to strip out
-   * this information in release builds as needed.
-   *
-   * @see <a href="https://issuetracker.google.com/issues/362780328">Upstream issue</a>
-   */
-  public val composeIncludeSourceInformationEverywhereByDefault: Boolean
-    get() =
-      resolver.booleanValue(
-        "foundry.compose.includeSourceInformationEverywhereByDefault",
-        defaultValue = true,
-      )
-
-  /**
    * When this property is present, the "internalRelease" build variant will have an application id
    * of "com.Slack.prototype", instead of "com.Slack.internal".
    *


### PR DESCRIPTION
includeSourceInformation is always enabled in kotlin 2.1.20

live literals are gone in newer AGP versions

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->