### PR TITLE
Upgrade skate and intellij versions and fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -362,7 +362,7 @@ subprojects {
         }
       }
       project.dependencies {
-        configure<IntelliJPlatformDependenciesExtension> { intellijIdeaCommunity("2024.2.1") }
+        configure<IntelliJPlatformDependenciesExtension> { intellijIdeaCommunity("2024.3.1") }
       }
 
       if (hasProperty("FoundryIntellijArtifactoryBaseUrl")) {

--- a/platforms/intellij/skate/gradle.properties
+++ b/platforms/intellij/skate/gradle.properties
@@ -2,7 +2,7 @@ INTELLIJ_PLUGIN=true
 PLUGIN_ID=com.slack.intellij.skate
 PLUGIN_NAME=Skate
 PLUGIN_DESCRIPTION=A plugin for IntelliJ and Android Studio for faster Kotlin and Android development!
-VERSION_NAME=0.8.0
+VERSION_NAME=0.9.0
 PLUGIN_SINCE_BUILD=243
 ARTIFACTORY_URL_SUFFIX=skate
 # Opt-out flag for bundling Kotlin standard library.

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/ui/SkateConfigUI.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/ui/SkateConfigUI.kt
@@ -54,10 +54,13 @@ internal class SkateConfigUI(
       }
       row(SkateBundle.message("skate.configuration.choosePath.title")) {
         textFieldWithBrowseButton(
-            SkateBundle.message("skate.configuration.choosePath.dialog.title"),
+            FileChoosing.singleMdFileChooserDescriptor()
+              .withTitle(SkateBundle.message("skate.configuration.choosePath.dialog.title"))
+              .toString(),
             project,
-            FileChoosing.singleMdFileChooserDescriptor(),
-          )
+          ) { chosenFile ->
+            chosenFile.presentableUrl
+          }
           .bindText(
             getter = {
               LocalFileSystem.getInstance().extractPresentableUrl(settings.whatsNewFilePath)


### PR DESCRIPTION
I realized we missed updating to intelliJ `2024.3` in the `build.gradle.kts` file.

Also adjusted in `SkateConfigUI` based on this error message:
```
> Task :platforms:intellij:skate:compileKotlin FAILED
e: file:///Users/liu.k/Developer/foundry/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/ui/SkateConfigUI.kt:56:9 Using 'textFieldWithBrowseButton(String? = ..., Project? = ..., FileChooserDescriptor = ..., ((chosenFile: VirtualFile) -> String)? = ...): Cell<TextFieldWithBrowseButton>' is an error. Use [Row.textFieldWithBrowseButton(String, Project?, ((VirtualFile) -> String)?)] or [Row.textFieldWithBrowseButton(FileChooserDescriptor, Project?, ((VirtualFile) -> String)?)] together with [FileChooserDescriptor.withTitle]

[Incubating] Problems report is available at: file:///Users/liu.k/Developer/foundry/build/reports/problems/problems-report.html
```