### PR TITLE
Prevent Project Gen deadlock with invokeLater and a modeless dialog

### DIFF
--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenMenuAction.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenMenuAction.kt
@@ -18,12 +18,14 @@ package foundry.intellij.skate.projectgen
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import foundry.intellij.skate.tracing.SkateSpanBuilder
 import foundry.intellij.skate.tracing.SkateTracingEvent
 import foundry.intellij.skate.util.getTraceReporter
 import foundry.intellij.skate.util.isProjectGenMenuActionEnabled
 import foundry.intellij.skate.util.isTracingEnabled
+import com.intellij.openapi.actionSystem.ActionManager
 import java.time.Instant
 
 class ProjectGenMenuAction : AnAction() {
@@ -31,7 +33,19 @@ class ProjectGenMenuAction : AnAction() {
     val currentProject = e.project ?: return
     if (!currentProject.isProjectGenMenuActionEnabled()) return
     val startTimestamp = Instant.now()
-    ProjectGenWindow(currentProject, e).show()
+
+    val dialog =
+      ProjectGenWindow(currentProject, e).apply {
+        onOk = {
+          ApplicationManager.getApplication().invokeLater {
+            val am = ActionManager.getInstance()
+            val sync = am.getAction("Android.SyncProject")
+            sync.actionPerformed(e)
+          }
+        }
+      }
+
+    dialog.show()
 
     if (currentProject.isTracingEnabled()) {
       sendUsageTrace(currentProject, startTimestamp)

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenMenuAction.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenMenuAction.kt
@@ -15,6 +15,7 @@
  */
 package foundry.intellij.skate.projectgen
 
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -25,7 +26,6 @@ import foundry.intellij.skate.tracing.SkateTracingEvent
 import foundry.intellij.skate.util.getTraceReporter
 import foundry.intellij.skate.util.isProjectGenMenuActionEnabled
 import foundry.intellij.skate.util.isTracingEnabled
-import com.intellij.openapi.actionSystem.ActionManager
 import java.time.Instant
 
 class ProjectGenMenuAction : AnAction() {

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindow.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindow.kt
@@ -35,9 +35,12 @@ class ProjectGenWindow(currentProject: Project, private val event: AnActionEvent
       .normalize()
       .also { check(Files.isDirectory(it)) { "Must pass a valid directory" } }
 
+  var onOk: (() -> Unit)? = null
+
   init {
     init()
     title = "Project Generator"
+    isModal = false
   }
 
   override fun createCenterPanel(): JComponent {
@@ -54,12 +57,10 @@ class ProjectGenWindow(currentProject: Project, private val event: AnActionEvent
 
   override fun doOKAction() {
     super.doOKAction()
+    onOk?.invoke()
   }
 
   override fun dismissDialogAndSync() {
     doOKAction()
-    val am: ActionManager = ActionManager.getInstance()
-    val sync: AnAction = am.getAction("Android.SyncProject")
-    sync.actionPerformed(event)
   }
 }

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindow.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindow.kt
@@ -15,8 +15,6 @@
  */
 package foundry.intellij.skate.projectgen
 
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
@@ -27,7 +25,7 @@ import java.nio.file.Paths
 import javax.swing.Action
 import javax.swing.JComponent
 
-class ProjectGenWindow(currentProject: Project, private val event: AnActionEvent) :
+class ProjectGenWindow(currentProject: Project, private val event: AnActionEvent?) :
   DialogWrapper(currentProject), ProjectGenUi.Events {
 
   private val projectPath =

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
@@ -1,0 +1,7 @@
+package foundry.intellij.skate.projectgen
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+
+class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
+
+}

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
@@ -1,7 +1,39 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foundry.intellij.skate.projectgen
 
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+import org.junit.Test
 
 class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
+  @Test
+  fun `test onOK callback is invoked on OK`() {
+    var wasCalled = false
 
+    val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
+
+    // simulate clicking OK
+    dialog.doOKAction()
+
+    assertTrue("expect onOk is called when OK is pressed", wasCalled)
+  }
+
+  @Test
+  fun `test dialog is not modal`() {
+    val dialog = ProjectGenWindow(project, null)
+    assertTrue("dialog should be modeless to avoid EDT deadlock", !dialog.isModal)
+  }
 }

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
@@ -21,10 +21,16 @@ import org.junit.Test
 
 class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
+  override fun setUp() {
+    super.setUp()
+    ensureProjectBasePathExists()
+  }
+
   // add this function so each test has an isolated temp dir
   private fun ensureProjectBasePathExists() {
     val basePath = project.basePath ?: return
     val dir = File(basePath)
+
     if (!dir.exists()) {
       dir.mkdirs()
     }
@@ -32,10 +38,7 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
   @Test
   fun `test onOK callback is invoked on OK`() {
-    ensureProjectBasePathExists()
-
     var wasCalled = false
-
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
 
     // simulate clicking OK
@@ -46,7 +49,6 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
   @Test
   fun `test onOK callback is invoked on dismissDialogAndSync`() {
-    ensureProjectBasePathExists()
     var wasCalled = false
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
 
@@ -57,7 +59,6 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
   @Test
   fun `test onOk is not called on cancel`() {
-    ensureProjectBasePathExists()
     var wasCalled = false
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
 
@@ -70,9 +71,8 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
   fun `test dialog is not modal`() {
     // dialog must be modeless to avoid deadlocking the EDT when triggering Android.SyncProject.
     // See: https://jb.gg/ij-platform-threading, nonModal() modality state
-    ensureProjectBasePathExists()
-
     val dialog = ProjectGenWindow(project, null)
+
     assertTrue("dialog should be modeless to avoid EDT deadlock", !dialog.isModal)
   }
 }

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
@@ -16,11 +16,24 @@
 package foundry.intellij.skate.projectgen
 
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+import java.io.File
 import org.junit.Test
 
 class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
+
+  // add this function so each test has an isolated temp dir
+  private fun ensureProjectBasePathExists() {
+    val basePath = project.basePath ?: return
+    val dir = File(basePath)
+    if (!dir.exists()) {
+      dir.mkdirs()
+    }
+  }
+
   @Test
   fun `test onOK callback is invoked on OK`() {
+    ensureProjectBasePathExists()
+
     var wasCalled = false
 
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
@@ -33,6 +46,7 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
   @Test
   fun `test onOK callback is invoked on dismissDialogAndSync`() {
+    ensureProjectBasePathExists()
     var wasCalled = false
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
 
@@ -43,6 +57,7 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
 
   @Test
   fun `test onOk is not called on cancel`() {
+    ensureProjectBasePathExists()
     var wasCalled = false
     val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
 
@@ -55,6 +70,8 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
   fun `test dialog is not modal`() {
     // dialog must be modeless to avoid deadlocking the EDT when triggering Android.SyncProject.
     // See: https://jb.gg/ij-platform-threading, nonModal() modality state
+    ensureProjectBasePathExists()
+
     val dialog = ProjectGenWindow(project, null)
     assertTrue("dialog should be modeless to avoid EDT deadlock", !dialog.isModal)
   }

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/projectgen/ProjectGenWindowTest.kt
@@ -32,7 +32,29 @@ class ProjectGenWindowTest : LightPlatformCodeInsightFixture4TestCase() {
   }
 
   @Test
+  fun `test onOK callback is invoked on dismissDialogAndSync`() {
+    var wasCalled = false
+    val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
+
+    dialog.dismissDialogAndSync()
+
+    assertTrue("expect onOk is called when dismissDialogAndSync is invoked", wasCalled)
+  }
+
+  @Test
+  fun `test onOk is not called on cancel`() {
+    var wasCalled = false
+    val dialog = ProjectGenWindow(project, null).apply { onOk = { wasCalled = true } }
+
+    dialog.doCancelAction()
+
+    assertTrue("onOk should not be called when cancel is pressed", !wasCalled)
+  }
+
+  @Test
   fun `test dialog is not modal`() {
+    // dialog must be modeless to avoid deadlocking the EDT when triggering Android.SyncProject.
+    // See: https://jb.gg/ij-platform-threading, nonModal() modality state
     val dialog = ProjectGenWindow(project, null)
     assertTrue("dialog should be modeless to avoid EDT deadlock", !dialog.isModal)
   }


### PR DESCRIPTION
We've received several notes about project gen deadlocking newer versions of Android Studio, and here is the [issue](https://github.com/slackhq/foundry/issues/1288) for it.

I was able to reproduce the issue on main.

After the changes, I'm able to load the subproject without deadlock:
<img src="https://github.com/user-attachments/assets/82cc88ab-e5d1-4932-95ea-2c17a69564ae" width="400" />

I wrote a few unit tests to confirm:
- `onOk` is called on `.doOKAction()` and `.dismissDialogAndSync()`.
- the Dialog is explicitly not modal.
- `onOk` is not called when cancelled.
