### PR TITLE
Always set target SDK in androidx.benchmark projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 **Unreleased**
 --------------
 
+- Always set targetSdk in `androidx.benchmark` projects.
+- Remove Guava dependency from version-number artifact.
+
 0.26.0
 ------
 


### PR DESCRIPTION
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->