### PR TITLE
Implement ProjectDependenciesDumpTask

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryBasePlugin.kt
@@ -18,6 +18,7 @@ package foundry.gradle
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
 import com.diffplug.spotless.LineEnding
+import foundry.gradle.avoidance.ProjectDependenciesDumpTask
 import foundry.gradle.develocity.NoOpBuildScanAdapter
 import foundry.gradle.develocity.findAdapter
 import foundry.gradle.stats.ModuleStatsTasks
@@ -109,7 +110,11 @@ internal class FoundryBasePlugin @Inject constructor(private val buildFeatures: 
     }
 
     // Everything in here applies to all projects
+
+    // Project deps generation
+    ProjectDependenciesDumpTask.register(target)
     target.configureClasspath(foundryProperties)
+
     if (!this.buildFeatures.isolatedProjects.requested.getOrElse(false)) {
       // TODO https://github.com/diffplug/spotless/issues/1979
       target.configureSpotless(foundryProperties)

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/avoidance/ProjectDependenciesDumpTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/avoidance/ProjectDependenciesDumpTask.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.gradle.avoidance
+
+import foundry.common.flatMapToSet
+import foundry.gradle.FoundryShared
+import foundry.gradle.register
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+/** Task to dump the set of direct project dependencies to an [outputFile]. */
+@CacheableTask
+public abstract class ProjectDependenciesDumpTask : DefaultTask() {
+
+  @get:Input public abstract val projectPaths: SetProperty<String>
+
+  @get:OutputFile public abstract val outputFile: RegularFileProperty
+
+  init {
+    group = FoundryShared.FOUNDRY_TASK_GROUP
+    description = "Dumps project dependencies to an output file."
+  }
+
+  @TaskAction
+  internal fun dump() {
+    outputFile.get().asFile.writeText(projectPaths.get().sorted().joinToString("\n"))
+  }
+
+  public companion object {
+    public const val NAME: String = "dumpProjectDependencies"
+
+    public fun register(project: Project): TaskProvider<ProjectDependenciesDumpTask> =
+      project.tasks.register<ProjectDependenciesDumpTask>(NAME) {
+        projectPaths.addAll(project.directProjectDependencies)
+        outputFile.set(project.layout.projectDirectory.file("gradle/implicit-projects.txt"))
+      }
+
+    private val Project.directProjectDependencies: Provider<Set<String>>
+      get() {
+        return provider {
+          configurations
+            .filter { c -> !c.isCanBeResolved }
+            .flatMapToSet { c ->
+              c.dependencies.filterIsInstance<ProjectDependency>().map { it.path }
+            }
+        }
+      }
+  }
+}

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/avoidance/ProjectDependenciesDumpTask.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/avoidance/ProjectDependenciesDumpTask.kt
@@ -60,11 +60,9 @@ public abstract class ProjectDependenciesDumpTask : DefaultTask() {
     private val Project.directProjectDependencies: Provider<Set<String>>
       get() {
         return provider {
-          configurations
-            .filter { c -> !c.isCanBeResolved }
-            .flatMapToSet { c ->
-              c.dependencies.filterIsInstance<ProjectDependency>().map { it.path }
-            }
+          configurations.flatMapToSet { c ->
+            c.dependencies.filterIsInstance<ProjectDependency>().map { it.path }
+          }
         }
       }
   }


### PR DESCRIPTION
This pull request introduces the `ProjectDependenciesDumpTask`, an alternative to `GenerateDependencyGraphTask`, where we'll generate simple direct deps and construct a dag ourselves outside of gradle