### PR TITLE
Simplify debuggable androidTest

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -863,19 +863,13 @@ internal class StandardProjectConfigurations(
               foundryExtension.androidHandler.featuresHandler.androidTestAllowedVariants.orNull
                 ?.contains(builder.name) != false
           builder.androidTest.enable = variantEnabled
-          if (variantEnabled) {
-            // Ensure there's a manifest file present and has its debuggable flag set correctly
-            if (
-              foundryProperties.strictMode && foundryProperties.strictValidateAndroidTestManifest
-            ) {
-              val manifest = project.file("src/androidTest/AndroidManifest.xml")
-              check(manifest.exists()) {
-                "AndroidManifest.xml is missing from src/androidTest. Ensure it exists and also is set to debuggable!"
-              }
-              check(manifest.readText().contains("android:debuggable=\"true\"")) {
-                "AndroidManifest.xml in src/androidTest is missing the debuggable flag! Ensure it is set to 'android:debuggable=\"true\"'"
-              }
-            }
+
+          // Explicitly mark the test APK as debuggable for debugging purposes
+          // Don't do this for benchmark projects as those must not be debuggable
+          val hasBenchmarkPlugin =
+            plugins.hasPlugin("androidx.baselineprofile") || plugins.hasPlugin("androidx.benchmark")
+          if (!hasBenchmarkPlugin) {
+            builder.androidTest.debuggable = true
           }
         }
 

--- a/platforms/intellij/compose/src/jvmMain/kotlin/foundry/intellij/compose/projectgen/models.kt
+++ b/platforms/intellij/compose/src/jvmMain/kotlin/foundry/intellij/compose/projectgen/models.kt
@@ -220,31 +220,6 @@ internal data class AndroidLibraryFeature(
     }
     resourcesPrefix?.let { builder.addStatement("resources(\"$it\")") }
   }
-
-  override fun renderFiles(projectDir: Path) {
-    if (androidTest) {
-      val androidTestDir = projectDir.resolve("src/androidTest")
-      androidTestDir.createDirectories()
-
-      // Write the manifest file
-      androidTestDir
-        .resolve("AndroidManifest.xml")
-        // language=XML
-        .writeText(
-          """
-        <?xml version="1.0" encoding="utf-8"?>
-        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-            <!-- Necessary for debugging to work since our libraries are single-variant. -->
-            <application android:debuggable="true" />
-        </manifest>
-        """
-            .trimIndent()
-        )
-
-      // Write the placeholder test file
-      writePlaceholderFileTo(androidTestDir, packageName)
-    }
-  }
 }
 
 internal data class KotlinFeature(val packageName: String, val isAndroid: Boolean) :


### PR DESCRIPTION
We can use just this simple API now to do this and avoid needing to add a dummy manifest just to set this

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->