### PR TITLE
Always defensively patch KSP tasks with sqldelight and viewbinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- Always defensively patch KSP tasks with sqldelight and viewbinding.
+
 0.27.4
 ------
 

--- a/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
+++ b/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.11.0-alpha10" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.11.0-alpha10">
+<issues format="6" by="lint 8.11.0-alpha10" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.11.0-alpha10">
 
     <issue
         id="AvoidUsingNotNullOperator"
@@ -63,7 +63,7 @@
         errorLine2="                    ~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryExtension.kt"
-            line="1212"
+            line="1146"
             column="21"/>
     </issue>
 
@@ -85,7 +85,7 @@
         errorLine2="                                                                      ~~">
         <location
             file="src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt"
-            line="133"
+            line="138"
             column="71"/>
     </issue>
 
@@ -184,7 +184,7 @@
         errorLine2="                                      ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryProperties.kt"
-            line="972"
+            line="968"
             column="39"/>
     </issue>
 
@@ -345,17 +345,6 @@
     <issue
         id="InternalAgpApiUsage"
         message="Avoid using internal Android Gradle Plugin APIs"
-        errorLine1="import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/FoundryExtension.kt"
-            line="24"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="InternalAgpApiUsage"
-        message="Avoid using internal Android Gradle Plugin APIs"
         errorLine1="import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask"
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -393,7 +382,18 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt"
-            line="33"
+            line="35"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="InternalAgpApiUsage"
+        message="Avoid using internal Android Gradle Plugin APIs"
+        errorLine1="import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt"
+            line="36"
             column="1"/>
     </issue>
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -17,11 +17,8 @@
 
 package foundry.gradle
 
-import app.cash.sqldelight.gradle.SqlDelightExtension
-import app.cash.sqldelight.gradle.SqlDelightTask
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask
 import com.google.devtools.ksp.gradle.KspExtension
 import com.squareup.anvil.plugin.AnvilExtension
 import dev.zacsweers.metro.gradle.MetroPluginExtension
@@ -31,7 +28,6 @@ import foundry.gradle.anvil.AnvilMode
 import foundry.gradle.compose.COMPOSE_COMPILER_OPTION_PREFIX
 import foundry.gradle.dependencies.FoundryDependencies
 import foundry.gradle.properties.setDisallowChanges
-import foundry.gradle.util.addKspSource
 import foundry.gradle.util.configureKotlinCompilationTask
 import java.io.File
 import javax.inject.Inject
@@ -46,7 +42,6 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
-import org.jetbrains.kotlin.gradle.utils.named
 
 @DslMarker public annotation class FoundryExtensionMarker
 
@@ -103,9 +98,9 @@ constructor(
   }
 
   internal fun applyTo(project: Project) {
-    val logVerbose = foundryProperties.foundryExtensionVerbose
     // Dirty but necessary since the extension isn't configured yet when we call this
     project.afterEvaluateSafe {
+      val logVerbose = foundryProperties.foundryExtensionVerbose
       featuresHandler.applyTo(project)
 
       var kaptRequired = false
@@ -288,67 +283,6 @@ constructor(
 
                 if (daggerConfig.testFixturesUseDagger) {
                   dependencies.add(kspConfiguration("testFixtures"), "$anvilPackage:compiler")
-                }
-
-                // Make KSP depend on sqldelight and viewbinding tasks
-                // This is opt-in as it's better for build performance to skip this linking if
-                // possible
-                // TODO KSP is supposed to do this automatically in android projects per
-                //  https://github.com/google/ksp/pull/1739, but that doesn't seem to actually work
-                //  let's make this optional
-                // afterEvaluate is necessary in order to wait for tasks to exist
-                if (
-                  foundryProperties.kspConnectSqlDelight || foundryProperties.kspConnectViewBinding
-                ) {
-                  afterEvaluate {
-                    if (
-                      foundryProperties.kspConnectSqlDelight &&
-                        pluginManager.hasPlugin("app.cash.sqldelight")
-                    ) {
-                      val dbNames = extensions.getByType<SqlDelightExtension>().databases.names
-                      val sourceSet =
-                        when {
-                          isKotlinMultiplatform -> "CommonMain"
-                          isAndroidLibrary -> "Release"
-                          else -> "Main"
-                        }
-                      val sourceSetKspName =
-                        when {
-                          isKotlinMultiplatform -> "CommonMainMetadata"
-                          isAndroidLibrary -> "Release"
-                          else -> ""
-                        }
-                      for (dbName in dbNames) {
-                        val sqlDelightTask =
-                          tasks.named<SqlDelightTask>("generate${sourceSet}${dbName}Interface")
-                        val outputProvider = sqlDelightTask.flatMap { it.outputDirectory }
-                        project.addKspSource(
-                          "ksp${sourceSetKspName}Kotlin",
-                          sqlDelightTask,
-                          outputProvider,
-                        )
-                      }
-                    }
-
-                    // If using viewbinding, need to wire those up too
-                    if (
-                      foundryProperties.kspConnectViewBinding &&
-                        isAndroidLibrary &&
-                        !foundryProperties.libraryWithVariants &&
-                        androidHandler.isViewBindingEnabled
-                    ) {
-                      val databindingTask =
-                        tasks.named<DataBindingGenBaseClassesTask>(
-                          "dataBindingGenBaseClassesRelease"
-                        )
-                      val databindingOutputProvider = databindingTask.flatMap { it.sourceOutFolder }
-                      project.addKspSource(
-                        "kspReleaseKotlin",
-                        databindingTask,
-                        databindingOutputProvider,
-                      )
-                    }
-                  }
                 }
               }
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryProperties.kt
@@ -409,10 +409,6 @@ internal constructor(
   public val moshixGenerateProguardRules: Boolean
     get() = booleanProperty("moshix.generateProguardRules", defaultValue = true)
 
-  /** Flag to connect SqlDelight sources to KSP. */
-  public val kspConnectSqlDelight: Boolean
-    get() = booleanProperty("foundry.ksp.connect.sqldelight")
-
   /** Flag to connect ViewBinding sources to KSP. */
   public val kspConnectViewBinding: Boolean
     get() = booleanProperty("foundry.ksp.connect.viewbinding")

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -361,7 +361,7 @@ internal class StandardProjectConfigurations(
       // This is opt-in as it's better for build performance to skip this linking if
       // possible. Required with KSP 2.0.2 now if sqldelight is enabled :|
       // TODO KSP is supposed to do this automatically in android projects per
-      //  https://github.com/google/ksp/pull/1739, but that doesn't seem to actually work
+      //  https://github.com/google/ksp/issues/2493, but that doesn't seem to actually work
       //  let's make this optional
       // afterEvaluate is necessary in order to wait for tasks to exist
       afterEvaluate {

--- a/tools/skippy/lint-baseline.xml
+++ b/tools/skippy/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0-alpha08" type="baseline" client="gradle" dependencies="false" name="AGP (8.9.0)" variant="all" version="8.10.0-alpha08">
+<issues format="6" by="lint 8.11.0-alpha10" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.11.0-alpha10">
 
     <issue
         id="AvoidUsingNotNullOperator"
@@ -10,6 +10,28 @@
             file="src/main/kotlin/foundry/skippy/AffectedProjectsComputer.kt"
             line="339"
             column="52"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="        ObjectInputStream(serializedDependencyGraph!!.inputStream())"
+        errorLine2="                                                   ~~">
+        <location
+            file="src/main/kotlin/foundry/skippy/ComputeAffectedProjectsCli.kt"
+            line="118"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="AvoidUsingNotNullOperator"
+        message="Avoid using the `!!` operator"
+        errorLine1="          graphEdges!!.readLines().map { line ->"
+        errorLine2="                    ~~">
+        <location
+            file="src/main/kotlin/foundry/skippy/ComputeAffectedProjectsCli.kt"
+            line="124"
+            column="21"/>
     </issue>
 
 </issues>


### PR DESCRIPTION
In KSP 2.0.2 they've changed this a bit and now we need to just defensively patch this always

<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->