### PR TITLE
Add plugin information tracking for Skate usage analytics

### DIFF
--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/pluginlist/RetrievePluginList.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/pluginlist/RetrievePluginList.kt
@@ -1,0 +1,67 @@
+package foundry.intellij.skate.pluginlist
+
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.diagnostic.Logger
+import foundry.intellij.skate.tracing.SkateSpanBuilder
+import foundry.intellij.skate.util.getTraceReporter
+import foundry.intellij.skate.util.isTracingEnabled
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@Serializable
+data class PluginInfo(
+    val id: String,
+    val name: String,
+    val version: String,
+    val enabled: Boolean,
+    val bundled: Boolean
+)
+
+class PluginListCollector : ProjectActivity {
+    private val log = Logger.getInstance(PluginListCollector::class.java)
+
+    override suspend fun execute(project: Project) {
+        val startTimestamp = Instant.now()
+        val pluginList = PluginManagerCore.plugins.map {
+            PluginInfo(
+                id = it.pluginId.idString,
+                name = it.name,
+                version = it.version,
+                enabled = it.isEnabled,
+                bundled = it.isBundled
+            )
+        }
+
+        // log to IDE log for testing
+        val pluginInfo = "Installed plugins:\n" + pluginList.joinToString("\n") {
+            "[${it.id}] ${it.name} v${it.version} (enabled=${it.enabled}, bundled=${it.bundled})"
+        }
+        log.info(pluginInfo)
+
+        if (project.isTracingEnabled()) {
+            val traceReporter = project.getTraceReporter()
+
+            // send data for individual plugin information
+            pluginList.forEach { plugin ->
+                val pluginSpanBuilder = SkateSpanBuilder().apply {
+                    addTag("event", "PLUGIN_INFO")
+                    addTag("plugin_id", plugin.id)
+                    addTag("plugin_name", plugin.name)
+                    addTag("plugin_version", plugin.version)
+                    addTag("plugin_enabled", plugin.enabled.toString())
+                    addTag("plugin_bundled", plugin.bundled.toString())
+                }
+
+                log.info("Sending plugin trace: ${pluginSpanBuilder.getKeyValueList()}")
+
+                traceReporter.createPluginUsageTraceAndSendTrace(
+                    "plugin_info",
+                    startTimestamp,
+                    pluginSpanBuilder.getKeyValueList()
+                )
+            }
+        }
+    }
+}

--- a/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/pluginlist/RetrievePluginList.kt
+++ b/platforms/intellij/skate/src/main/kotlin/foundry/intellij/skate/pluginlist/RetrievePluginList.kt
@@ -1,67 +1,86 @@
+/*
+ * Copyright (C) 2025 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package foundry.intellij.skate.pluginlist
 
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
-import com.intellij.openapi.diagnostic.Logger
 import foundry.intellij.skate.tracing.SkateSpanBuilder
 import foundry.intellij.skate.util.getTraceReporter
 import foundry.intellij.skate.util.isTracingEnabled
-import kotlinx.serialization.Serializable
 import java.time.Instant
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class PluginInfo(
-    val id: String,
-    val name: String,
-    val version: String,
-    val enabled: Boolean,
-    val bundled: Boolean
+  val id: String,
+  val name: String,
+  val version: String,
+  val enabled: Boolean,
+  val bundled: Boolean,
 )
 
 class PluginListCollector : ProjectActivity {
-    private val log = Logger.getInstance(PluginListCollector::class.java)
+  private val log = Logger.getInstance(PluginListCollector::class.java)
 
-    override suspend fun execute(project: Project) {
-        val startTimestamp = Instant.now()
-        val pluginList = PluginManagerCore.plugins.map {
-            PluginInfo(
-                id = it.pluginId.idString,
-                name = it.name,
-                version = it.version,
-                enabled = it.isEnabled,
-                bundled = it.isBundled
-            )
+  override suspend fun execute(project: Project) {
+    val startTimestamp = Instant.now()
+    val pluginList =
+      PluginManagerCore.plugins.map {
+        PluginInfo(
+          id = it.pluginId.idString,
+          name = it.name,
+          version = it.version,
+          enabled = it.isEnabled,
+          bundled = it.isBundled,
+        )
+      }
+
+    // log to IDE log for testing
+    val pluginInfo =
+      "Installed plugins:\n" +
+        pluginList.joinToString("\n") {
+          "[${it.id}] ${it.name} v${it.version} (enabled=${it.enabled}, bundled=${it.bundled})"
         }
+    log.info(pluginInfo)
 
-        // log to IDE log for testing
-        val pluginInfo = "Installed plugins:\n" + pluginList.joinToString("\n") {
-            "[${it.id}] ${it.name} v${it.version} (enabled=${it.enabled}, bundled=${it.bundled})"
-        }
-        log.info(pluginInfo)
+    if (project.isTracingEnabled()) {
+      val traceReporter = project.getTraceReporter()
 
-        if (project.isTracingEnabled()) {
-            val traceReporter = project.getTraceReporter()
+      // send data for individual plugin information
+      pluginList.forEach { plugin ->
+        val pluginSpanBuilder =
+          SkateSpanBuilder().apply {
+            addTag("event", "PLUGIN_INFO")
+            addTag("plugin_id", plugin.id)
+            addTag("plugin_name", plugin.name)
+            addTag("plugin_version", plugin.version)
+            addTag("plugin_enabled", plugin.enabled.toString())
+            addTag("plugin_bundled", plugin.bundled.toString())
+          }
 
-            // send data for individual plugin information
-            pluginList.forEach { plugin ->
-                val pluginSpanBuilder = SkateSpanBuilder().apply {
-                    addTag("event", "PLUGIN_INFO")
-                    addTag("plugin_id", plugin.id)
-                    addTag("plugin_name", plugin.name)
-                    addTag("plugin_version", plugin.version)
-                    addTag("plugin_enabled", plugin.enabled.toString())
-                    addTag("plugin_bundled", plugin.bundled.toString())
-                }
+        log.info("Sending plugin trace: ${pluginSpanBuilder.getKeyValueList()}")
 
-                log.info("Sending plugin trace: ${pluginSpanBuilder.getKeyValueList()}")
-
-                traceReporter.createPluginUsageTraceAndSendTrace(
-                    "plugin_info",
-                    startTimestamp,
-                    pluginSpanBuilder.getKeyValueList()
-                )
-            }
-        }
+        traceReporter.createPluginUsageTraceAndSendTrace(
+          "plugin_info",
+          startTimestamp,
+          pluginSpanBuilder.getKeyValueList(),
+        )
+      }
     }
+  }
 }

--- a/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
+++ b/platforms/intellij/skate/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
         <projectIndexingActivityHistoryListener implementation="foundry.intellij.skate.idemetrics.IndexingListener"/>
         <postStartupActivity implementation="foundry.intellij.skate.PostStartupActivityExtension"/>
         <postStartupActivity implementation="foundry.intellij.skate.ideinstall.InstallationLocationStartupActivity"/>
+        <postStartupActivity implementation="foundry.intellij.skate.pluginlist.PluginListCollector"/>
         <notificationGroup id="SkateInstallationLocation" displayType="BALLOON" isLogByDefault="true"/>
     </extensions>
 

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/SkateTraceReporterTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/SkateTraceReporterTest.kt
@@ -137,7 +137,7 @@ class SkateTraceReporterTest : BasePlatformTestCase() {
           "Studio Giraffe",
           "0.2.0",
         )
-    
+
     val expectedTags =
       mutableListOf(
         KeyValue("service_name", ValueType.STRING, SERVICE_NAME),

--- a/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/SkateTraceReporterTest.kt
+++ b/platforms/intellij/skate/src/test/kotlin/foundry/intellij/skate/SkateTraceReporterTest.kt
@@ -113,4 +113,55 @@ class SkateTraceReporterTest : BasePlatformTestCase() {
         )
     assertThat(listOfSpans).isNull()
   }
+
+  @Test
+  fun testPluginInfoTraceWithCorrectTags() {
+    val traceTags =
+      newTagBuilder().apply {
+        "event" tagTo "PLUGIN_INFO"
+        "plugin_id" tagTo "com.intellij.modules.platform"
+        "plugin_name" tagTo "Platform API"
+        "plugin_version" tagTo "2023.1.3"
+        "plugin_enabled" tagTo "true"
+        "plugin_bundled" tagTo "true"
+      }
+
+    val listOfSpans =
+      SkateTraceReporter(project)
+        .createPluginUsageTraceAndSendTrace(
+          "plugin_info",
+          Instant.now(),
+          traceTags,
+          traceId = ByteString.EMPTY,
+          parentId = ByteString.EMPTY,
+          "Studio Giraffe",
+          "0.2.0",
+        )
+    
+    val expectedTags =
+      mutableListOf(
+        KeyValue("service_name", ValueType.STRING, SERVICE_NAME),
+        KeyValue("database", ValueType.STRING, DATABASE_NAME),
+      )
+
+    val expectedSpanTags =
+      newTagBuilder().apply {
+        "skate_version" tagTo "0.2.0"
+        "ide_version" tagTo "Studio Giraffe"
+        "user" tagTo System.getenv("USER")
+        "project_name" tagTo project.name
+        "event" tagTo "PLUGIN_INFO"
+        "plugin_id" tagTo "com.intellij.modules.platform"
+        "plugin_name" tagTo "Platform API"
+        "plugin_version" tagTo "2023.1.3"
+        "plugin_enabled" tagTo "true"
+        "plugin_bundled" tagTo "true"
+      }
+
+    assertThat(listOfSpans).isNotNull()
+    if (listOfSpans != null) {
+      assertThat(listOfSpans.tags).isEqualTo(expectedTags)
+      assertThat(listOfSpans.spans.first().tags).isEqualTo(expectedSpanTags.toList())
+    }
+  }
 }


### PR DESCRIPTION
This sends plugin info data to the Skate dashboard as a way to track basic information on what plugins are installed for every user alongside Skate. 

- Includes: id, name, version, enabled status, bundled status.
- Tested by building the plugin and installing it locally, which then sent up a new event
- Also added a test to `SkateTraceReporterTest` 
