### PR TITLE
Stop echo-ing debug logs in CliktFoundryLogger

### DIFF
--- a/tools/skippy/src/main/kotlin/foundry/skippy/CliktFoundryLogger.kt
+++ b/tools/skippy/src/main/kotlin/foundry/skippy/CliktFoundryLogger.kt
@@ -23,7 +23,8 @@ internal fun FoundryLogger.Companion.clikt(command: BaseCliktCommand<*>): Foundr
 
 private class CliktFoundryLogger(private val command: BaseCliktCommand<*>) : FoundryLogger {
   override fun debug(message: String) {
-    command.echo(message)
+    // Ignore debug logs as they're very chatty. Most usages branch on a `--debug` flag,
+    // which then redirects logs to lifecycle(...) below
   }
 
   override fun info(message: String) {


### PR DESCRIPTION
They're just too chatty. Since we have no way to log with a level/severity in Clikt, we just need to ignore debug logs. If people want logs, they can use `--debug` which will enable logging via lifecycle()
