### PR TITLE
[Skippy] Add Spotlight output

### DIFF
--- a/tools/skippy/src/main/kotlin/foundry/skippy/AffectedProjectsComputer.kt
+++ b/tools/skippy/src/main/kotlin/foundry/skippy/AffectedProjectsComputer.kt
@@ -52,10 +52,10 @@ import okio.Path
  * that are determined to be affected. This is intended to be used as an input to a subsequent
  * Gradle invocation (usually as a file) to inform which projects can be avoided.
  *
- * A secondary output file is [AffectedProjectsResult.focusProjects]. This is a set of Gradle
- * project paths that can be written to a `focus.settings.gradle` file that can be used with the
- * dropbox/focus plugin, and will be a minimal list of projects needed to build the affected
- * projects.
+ * A secondary output is [AffectedProjectsResult.buildProjects]. This is written as 2 files which
+ * both contain a minimal list of projects needed to build the affected projects:
+ * - `focus.settings.gradle`: Can be used with the dropbox/focus plugin.
+ * - `spotlight_projects.txt`: Can be used with joshfriend/spotlight plugin.
  *
  * With both outputs, if any "never-skippable" files [SkippyConfig.neverSkipPatterns] are changed,
  * then no output file is produced and all projects are considered affected. If a file is produced

--- a/tools/skippy/src/main/kotlin/foundry/skippy/AffectedProjectsResult.kt
+++ b/tools/skippy/src/main/kotlin/foundry/skippy/AffectedProjectsResult.kt
@@ -19,6 +19,10 @@ import java.util.SortedSet
 
 public data class AffectedProjectsResult(
   val affectedProjects: SortedSet<String>,
-  val focusProjects: SortedSet<String>,
+  val buildProjects: SortedSet<String>,
   val affectedAndroidTestProjects: SortedSet<String>,
-)
+) {
+  @Deprecated("Use buildProjects instead", ReplaceWith("buildProjects"))
+  val focusProjects: SortedSet<String>
+    get() = buildProjects
+}

--- a/tools/skippy/src/main/kotlin/foundry/skippy/SkippyOutput.kt
+++ b/tools/skippy/src/main/kotlin/foundry/skippy/SkippyOutput.kt
@@ -19,6 +19,7 @@ import foundry.common.prepareForGradleOutput
 import foundry.skippy.SkippyOutput.Companion.AFFECTED_ANDROID_TEST_PROJECTS_FILE_NAME
 import foundry.skippy.SkippyOutput.Companion.AFFECTED_PROJECTS_FILE_NAME
 import foundry.skippy.SkippyOutput.Companion.FOCUS_SETTINGS_FILE_NAME
+import foundry.skippy.SkippyOutput.Companion.SPOTLIGHT_FILE_NAME
 import okio.FileSystem
 import okio.Path
 
@@ -35,11 +36,15 @@ public interface SkippyOutput {
   /** An output .focus file that could be used with the Focus plugin. */
   public val outputFocusFile: Path
 
+  /** An output spotlight file that could be used with the Spotlight plugin. */
+  public val outputSpotlightFile: Path
+
   public companion object {
     internal const val AFFECTED_PROJECTS_FILE_NAME: String = "affected_projects.txt"
     internal const val AFFECTED_ANDROID_TEST_PROJECTS_FILE_NAME: String =
       "affected_android_test_projects.txt"
     internal const val FOCUS_SETTINGS_FILE_NAME: String = "focus.settings.gradle"
+    internal const val SPOTLIGHT_FILE_NAME: String = "spotlight_projects.txt"
   }
 }
 
@@ -48,6 +53,7 @@ public class SimpleSkippyOutput(public override val subDir: Path) : SkippyOutput
   public override val affectedAndroidTestProjectsFile: Path =
     subDir.resolve(AFFECTED_ANDROID_TEST_PROJECTS_FILE_NAME)
   public override val outputFocusFile: Path = subDir.resolve(FOCUS_SETTINGS_FILE_NAME)
+  public override val outputSpotlightFile: Path = subDir.resolve(SPOTLIGHT_FILE_NAME)
 }
 
 public class WritableSkippyOutput(tool: String, outputDir: Path, fs: FileSystem) : SkippyOutput {
@@ -71,5 +77,9 @@ public class WritableSkippyOutput(tool: String, outputDir: Path, fs: FileSystem)
 
   public override val outputFocusFile: Path by lazy {
     delegate.outputFocusFile.prepareForGradleOutput(fs)
+  }
+
+  override val outputSpotlightFile: Path by lazy {
+    delegate.outputSpotlightFile.prepareForGradleOutput(fs)
   }
 }

--- a/tools/skippy/src/test/kotlin/foundry/skippy/AffectedProjectsComputerTest.kt
+++ b/tools/skippy/src/test/kotlin/foundry/skippy/AffectedProjectsComputerTest.kt
@@ -255,7 +255,7 @@ private fun AffectedProjectsComputer.assertComputed(
 ) {
   val result = compute().checkNotNull()
   assertThat(result.affectedProjects).containsExactlyElementsIn(expectedAffectedProjects)
-  assertThat(result.focusProjects).containsExactlyElementsIn(expectedFocusProjects)
+  assertThat(result.buildProjects).containsExactlyElementsIn(expectedFocusProjects)
   assertThat(result.affectedAndroidTestProjects)
     .containsExactlyElementsIn(expectedAffectedAndroidTestProjects)
 }
@@ -270,5 +270,5 @@ private fun AffectedProjectsResult?.assertNull() {
 private fun AffectedProjectsResult?.assertEmpty() {
   val result = checkNotNull()
   assertThat(result.affectedProjects).isEmpty()
-  assertThat(result.focusProjects).isEmpty()
+  assertThat(result.buildProjects).isEmpty()
 }

--- a/tools/skippy/src/test/kotlin/foundry/skippy/SkippyRunnerTest.kt
+++ b/tools/skippy/src/test/kotlin/foundry/skippy/SkippyRunnerTest.kt
@@ -113,7 +113,7 @@ class SkippyRunnerTest {
       assertComputed(
         tool,
         expectedAffectedProjects = listOf(":$projectName"),
-        expectedFocusProjects = listOf(":$projectName"),
+        expectedBuildProjects = listOf(":$projectName"),
         expectedAffectedAndroidTestProjects = listOf(":$projectName"),
       )
     }
@@ -150,7 +150,7 @@ class SkippyRunnerTest {
       assertComputed(
         tool,
         expectedAffectedProjects = listOf(":$barProject"),
-        expectedFocusProjects = listOf(":$barProject"),
+        expectedBuildProjects = listOf(":$barProject"),
         // Lint xml file doesn't affect android tests
         expectedAffectedAndroidTestProjects = emptyList(),
       )
@@ -158,7 +158,7 @@ class SkippyRunnerTest {
     assertComputed(
       "unitTest",
       expectedAffectedProjects = emptyList(),
-      expectedFocusProjects = emptyList(),
+      expectedBuildProjects = emptyList(),
       expectedAffectedAndroidTestProjects = emptyList(),
     )
   }
@@ -169,14 +169,16 @@ class SkippyRunnerTest {
   private fun assertComputed(
     tool: String,
     expectedAffectedProjects: List<String>,
-    expectedFocusProjects: List<String>,
+    expectedBuildProjects: List<String>,
     expectedAffectedAndroidTestProjects: List<String>,
   ) {
-    val includedProjects = expectedFocusProjects.map { "include(\"$it\")" }
+    val includedProjects = expectedBuildProjects.map { "include(\"$it\")" }
     assertThat(skippyOutput(tool, SkippyOutput.AFFECTED_PROJECTS_FILE_NAME).readLines(fs))
       .containsExactlyElementsIn(expectedAffectedProjects)
     assertThat(skippyOutput(tool, SkippyOutput.FOCUS_SETTINGS_FILE_NAME).readLines(fs))
       .containsExactlyElementsIn(includedProjects)
+    assertThat(skippyOutput(tool, SkippyOutput.SPOTLIGHT_FILE_NAME).readLines(fs))
+      .containsExactlyElementsIn(expectedBuildProjects)
     assertThat(
         skippyOutput(tool, SkippyOutput.AFFECTED_ANDROID_TEST_PROJECTS_FILE_NAME).readLines(fs)
       )


### PR DESCRIPTION
Similar to what we do for Focus, we now output a list of projects which can be piped through to Spotlight.