### PR TITLE
Add `CODEOWNER` for open source Salesforce/Slack compliance

### DIFF
--- a/CODEOWNER
+++ b/CODEOWNER
@@ -1,0 +1,3 @@
+# Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow


### PR DESCRIPTION
#### Description:
- There was a request from Slack to add a CODEOWNER file for open source compliance. Feel free to read full request below:

> One of the many responsibilities of the OSPO is to ensure compliance of existing and new Open Source projects and GitHub repositories with our Policies and Procedures. 
> 
> You are receiving this Email because you are tagged as a Maintainer/Collaborator for the http://github.com/slackhq/foundry repository.
> 
> The reason for this Email is that it's been determined that the `CODEOWNERS` file for your repo is either non-existant or, more likely, incorrect. If you are missing the `CODEOWNERS` file you can copy over the one from the https://github.com/salesforce/oss-template repo.
> 
> If you do have a `CODEOWNERS` file, it is likely then missing one or both of these required 2 lines, or else they are in an incorrect or unknown format:
> 
>     #ECCN:Open Source
>     #GUSINFO:Open Source,Open Source Workflow
> 
> These lines must be present in this exact format (but left aligned). If for example, your ECCN line is something like:
> 
>     #ECCN:5D002
> 
> or
> 
>     #ECCN:Open Source 5D002
> 
> then the file needs to be edited and corrected. All Open Source projects must have that ECCN value. Again, the `CODEOWNERS` file from the `oss-template` repo contains the correct format and data.
> 
> Any repos found to be still non-compliant after 45 days will be ARCHIVED and later moved to `private` visibility.