### PR TITLE
Skip Maven Central publishing wait and set validateDeployment to false

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,7 +305,7 @@ subprojects {
     }
 
     configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(automaticRelease = true)
+      publishToMavenCentral(automaticRelease = true, validateDeployment = false)
       signAllPublications()
     }
   }


### PR DESCRIPTION
Running into this same issue: https://github.com/vanniktech/gradle-maven-publish-plugin/issues/1206, where releasing foundry times out after 15 minutes. Setting `validateDeployment = false` should resolve this issue.

Thanks @ZacSweers for the suggestion here 🙇 
<!--
  ⬆ Put your description above this! ⬆

  Please be descriptive and detailed.
  
  Please read our [Contributing Guidelines](https://github.com/tinyspeck/foundry/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Don't worry about deleting this, it's not visible in the PR!
-->