### PR TITLE
Enable Gradle Isolated Projects

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,10 +17,10 @@ Code formatting is checked via [Spotless](https://github.com/diffplug/spotless).
 use the `spotlessApply` command.
 
 ```bash
-./gradlew spotlessApply -Porg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
 ```
 
-> **Note**: The `-Porg.gradle.unsafe.isolated-projects=false` flag is required because this project
+> **Note**: The `-Dorg.gradle.unsafe.isolated-projects=false` flag is required because this project
 > uses Gradle's isolated projects feature, which Spotless does not yet support.
 > See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for details.
 
@@ -30,7 +30,7 @@ The CLI module uses KSP for `@AutoService` annotations. Since KSP does not yet s
 projects, you must disable it when building the CLI:
 
 ```bash
-./gradlew :tools:cli:build -Porg.gradle.unsafe.isolated-projects=false
+./gradlew :tools:cli:build -Dorg.gradle.unsafe.isolated-projects=false
 ```
 
 Without this flag, the CLI JAR will not contain the service loader files and CLI commands will not

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,12 +17,24 @@ Code formatting is checked via [Spotless](https://github.com/diffplug/spotless).
 use the `spotlessApply` command.
 
 ```bash
-./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessApply -Porg.gradle.unsafe.isolated-projects=false
 ```
 
-> **Note**: The `-Dorg.gradle.unsafe.isolated-projects=false` flag is required because this project
+> **Note**: The `-Porg.gradle.unsafe.isolated-projects=false` flag is required because this project
 > uses Gradle's isolated projects feature, which Spotless does not yet support.
 > See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for details.
+
+### Building the CLI
+
+The CLI module uses KSP for `@AutoService` annotations. Since KSP does not yet support isolated
+projects, you must disable it when building the CLI:
+
+```bash
+./gradlew :tools:cli:build -Porg.gradle.unsafe.isolated-projects=false
+```
+
+Without this flag, the CLI JAR will not contain the service loader files and CLI commands will not
+be discoverable at runtime.
 
 Optionally, there are commit hooks in the repo you can enable by running the below
 ```bash

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,8 +17,12 @@ Code formatting is checked via [Spotless](https://github.com/diffplug/spotless).
 use the `spotlessApply` command.
 
 ```bash
-./gradlew spotlessApply
+./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
 ```
+
+> **Note**: The `-Dorg.gradle.unsafe.isolated-projects=false` flag is required because this project
+> uses Gradle's isolated projects feature, which Spotless does not yet support.
+> See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for details.
 
 Optionally, there are commit hooks in the repo you can enable by running the below
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,4 +145,4 @@ jobs:
         if: github.repository == 'slackhq/foundry'
         # Disable isolated projects for publishing because the CLI module requires KSP
         # to generate service loader files, and KSP doesn't support isolated projects yet
-        run: ./gradlew publish --quiet -Porg.gradle.unsafe.isolated-projects=false -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }}
+        run: ./gradlew publish --quiet -Dorg.gradle.unsafe.isolated-projects=false -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,4 +143,6 @@ jobs:
 
       - name: Publish snapshot
         if: github.repository == 'slackhq/foundry'
-        run: ./gradlew publish --quiet -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }}
+        # Disable isolated projects for publishing because the CLI module requires KSP
+        # to generate service loader files, and KSP doesn't support isolated projects yet
+        run: ./gradlew publish --quiet -Porg.gradle.unsafe.isolated-projects=false -PmavenCentralUsername=${{ secrets.SONATYPEUSERNAME }} -PmavenCentralPassword=${{ secrets.SONATYPEPASSWORD }}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -24,4 +24,7 @@ dependencies {
   // SAM with receiver plugin for Gradle plugin projects
   implementation("org.jetbrains.kotlin:kotlin-sam-with-receiver:${libs.versions.kotlin.get()}")
   // Note: Dokka and MavenPublish are applied via plugins block, not as dependencies
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Slack Technologies, LLC
+ * Copyright (C) 2022 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-  id("foundry.spotless")
-  id("foundry.kotlin-jvm-gradle")
-  alias(libs.plugins.mavenPublish)
-  alias(libs.plugins.lint)
-}
+plugins { `kotlin-dsl` }
 
 dependencies {
-  implementation(libs.okio)
-
-  compileOnly(gradleApi())
+  // Plugin dependencies - these become available in convention plugins
+  implementation(libs.gradlePlugins.spotless)
+  implementation(libs.gradlePlugins.kgp)
+  implementation(libs.gradlePlugins.detekt)
+  implementation(libs.gradlePlugins.sortDependencies)
+  // SAM with receiver plugin for Gradle plugin projects
+  implementation("org.jetbrains.kotlin:kotlin-sam-with-receiver:${libs.versions.kotlin.get()}")
+  // Note: Dokka and MavenPublish are applied via plugins block, not as dependencies
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Slack Technologies, LLC
+ * Copyright (C) 2022 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins {
-  id("foundry.spotless")
-  id("foundry.kotlin-jvm-gradle")
-  alias(libs.plugins.mavenPublish)
-  alias(libs.plugins.lint)
-}
+rootProject.name = "build-logic"
 
-dependencies {
-  implementation(libs.okio)
-
-  compileOnly(gradleApi())
+dependencyResolutionManagement {
+  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+  repositories {
+    mavenCentral()
+    google()
+    gradlePluginPortal()
+  }
 }

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension
+
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.plugin.sam.with.receiver")
+  id("com.squareup.sort-dependencies")
+}
+
+val jvmTargetVersion = JvmTarget.JVM_21
+val jdkVersion = 23
+
+extensions.configure<KotlinJvmProjectExtension> { explicitApi() }
+
+extensions.configure<SamWithReceiverExtension> {
+  annotation("org.gradle.api.HasImplicitReceiver")
+}
+
+extensions.configure<JavaPluginExtension> {
+  toolchain { languageVersion.set(JavaLanguageVersion.of(jdkVersion)) }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(jvmTargetVersion.target.toInt())
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions {
+    languageVersion.set(KotlinVersion.KOTLIN_2_2)
+    apiVersion.set(KotlinVersion.KOTLIN_2_2)
+    // Gradle forces older Kotlin, which results in warnings
+    allWarningsAsErrors.set(false)
+
+    check(this is KotlinJvmCompilerOptions)
+    this.jvmTarget.set(jvmTargetVersion)
+    jvmDefault.set(org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode.NO_COMPATIBILITY)
+    freeCompilerArgs.addAll(
+      // Required due to https://github.com/gradle/gradle/issues/24871
+      "-Xsam-conversions=class",
+      "-Xlambdas=class",
+      "-Xenhance-type-parameter-types-to-def-not-null",
+      "-Xjsr305=strict",
+      "-Xassertions=jvm",
+      "-Xemit-jvm-type-annotations",
+      "-Xtype-enhancement-improvements-strict-mode",
+      "-Xjspecify-annotations=strict",
+      "-Xannotation-default-target=param-property",
+      "-Xjdk-release=${jvmTargetVersion.target}",
+    )
+    optIn.addAll(
+      "kotlin.contracts.ExperimentalContracts",
+      "kotlin.experimental.ExperimentalTypeInference",
+      "kotlin.ExperimentalStdlibApi",
+      "kotlin.time.ExperimentalTime",
+    )
+  }
+}

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-gradle.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -26,8 +27,9 @@ plugins {
   id("com.squareup.sort-dependencies")
 }
 
-val jvmTargetVersion = JvmTarget.JVM_21
-val jdkVersion = 23
+val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val jvmTargetVersion = catalog.findVersion("jvmTarget").get().toString().let { JvmTarget.fromTarget(it) }
+val jdkVersion = catalog.findVersion("jdk").get().toString().toInt()
 
 extensions.configure<KotlinJvmProjectExtension> { explicitApi() }
 
@@ -73,4 +75,9 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
       "kotlin.time.ExperimentalTime",
     )
   }
+}
+
+// Configure Detekt jvmTarget when Detekt plugin is applied
+pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
+  tasks.withType<Detekt>().configureEach { jvmTarget = jvmTargetVersion.target }
 }

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.squareup.sort-dependencies")
+}
+
+val jvmTargetVersion = JvmTarget.JVM_21
+val jdkVersion = 23
+
+// Note: No explicit API for IntelliJ plugins
+
+extensions.configure<JavaPluginExtension> {
+  toolchain { languageVersion.set(JavaLanguageVersion.of(jdkVersion)) }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(jvmTargetVersion.target.toInt())
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions {
+    // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+    languageVersion.set(KotlinVersion.KOTLIN_2_0)
+    apiVersion.set(KotlinVersion.KOTLIN_2_0)
+    // IntelliJ forces older Kotlin, which results in warnings
+    allWarningsAsErrors.set(false)
+
+    check(this is KotlinJvmCompilerOptions)
+    this.jvmTarget.set(jvmTargetVersion)
+    jvmDefault.set(org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode.NO_COMPATIBILITY)
+    freeCompilerArgs.addAll(
+      "-Xenhance-type-parameter-types-to-def-not-null",
+      "-Xjsr305=strict",
+      "-Xassertions=jvm",
+      "-Xemit-jvm-type-annotations",
+      "-Xtype-enhancement-improvements-strict-mode",
+      "-Xjspecify-annotations=strict",
+      "-Xannotation-default-target=param-property",
+      "-Xjdk-release=${jvmTargetVersion.target}",
+    )
+    optIn.addAll(
+      "kotlin.contracts.ExperimentalContracts",
+      "kotlin.experimental.ExperimentalTypeInference",
+      "kotlin.ExperimentalStdlibApi",
+      "kotlin.time.ExperimentalTime",
+    )
+  }
+}

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm-intellij.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -23,8 +24,9 @@ plugins {
   id("com.squareup.sort-dependencies")
 }
 
-val jvmTargetVersion = JvmTarget.JVM_21
-val jdkVersion = 23
+val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val jvmTargetVersion = catalog.findVersion("jvmTargetIdea").get().toString().let { JvmTarget.fromTarget(it) }
+val jdkVersion = catalog.findVersion("jdk").get().toString().toInt()
 
 // Note: No explicit API for IntelliJ plugins
 
@@ -64,4 +66,9 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
       "kotlin.time.ExperimentalTime",
     )
   }
+}
+
+// Configure Detekt jvmTarget when Detekt plugin is applied
+pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
+  tasks.withType<Detekt>().configureEach { jvmTarget = jvmTargetVersion.target }
 }

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -24,8 +25,9 @@ plugins {
   id("com.squareup.sort-dependencies")
 }
 
-val jvmTargetVersion = JvmTarget.JVM_21
-val jdkVersion = 23
+val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val jvmTargetVersion = catalog.findVersion("jvmTarget").get().toString().let { JvmTarget.fromTarget(it) }
+val jdkVersion = catalog.findVersion("jdk").get().toString().toInt()
 
 extensions.configure<KotlinJvmProjectExtension> { explicitApi() }
 
@@ -63,4 +65,9 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
       "kotlin.time.ExperimentalTime",
     )
   }
+}
+
+// Configure Detekt jvmTarget when Detekt plugin is applied
+pluginManager.withPlugin("io.gitlab.arturbosch.detekt") {
+  tasks.withType<Detekt>().configureEach { jvmTarget = jvmTargetVersion.target }
 }

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.squareup.sort-dependencies")
+}
+
+val jvmTargetVersion = JvmTarget.JVM_21
+val jdkVersion = 23
+
+extensions.configure<KotlinJvmProjectExtension> { explicitApi() }
+
+extensions.configure<JavaPluginExtension> {
+  toolchain { languageVersion.set(JavaLanguageVersion.of(jdkVersion)) }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(jvmTargetVersion.target.toInt())
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions {
+    languageVersion.set(KotlinVersion.DEFAULT)
+    apiVersion.set(KotlinVersion.DEFAULT)
+    allWarningsAsErrors.set(true)
+
+    check(this is KotlinJvmCompilerOptions)
+    this.jvmTarget.set(jvmTargetVersion)
+    jvmDefault.set(org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode.NO_COMPATIBILITY)
+    freeCompilerArgs.addAll(
+      "-Xenhance-type-parameter-types-to-def-not-null",
+      "-Xjsr305=strict",
+      "-Xassertions=jvm",
+      "-Xemit-jvm-type-annotations",
+      "-Xtype-enhancement-improvements-strict-mode",
+      "-Xjspecify-annotations=strict",
+      "-Xannotation-default-target=param-property",
+      "-Xjdk-release=${jvmTargetVersion.target}",
+    )
+    optIn.addAll(
+      "kotlin.contracts.ExperimentalContracts",
+      "kotlin.experimental.ExperimentalTypeInference",
+      "kotlin.ExperimentalStdlibApi",
+      "kotlin.time.ExperimentalTime",
+    )
+  }
+}

--- a/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.kotlin-jvm.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import com.diffplug.gradle.spotless.KotlinExtension
+import com.diffplug.gradle.spotless.SpotlessExtension
+
+// Spotless doesn't support isolated projects
+// See: https://github.com/diffplug/spotless/issues/1979
+// Check both gradle property and system property (-D flag takes precedence)
+val isolatedProjectsFromGradleProperty =
+  providers
+    .gradleProperty("org.gradle.unsafe.isolated-projects")
+    .map { it.toBoolean() }
+    .getOrElse(false)
+val isolatedProjectsFromSystemProperty =
+  providers
+    .systemProperty("org.gradle.unsafe.isolated-projects")
+    .map { it.toBoolean() }
+    .orNull
+val isolatedProjectsEnabled = isolatedProjectsFromSystemProperty ?: isolatedProjectsFromGradleProperty
+
+if (isolatedProjectsEnabled) {
+  // Skip spotless configuration when isolated projects is enabled.
+  // Running spotless tasks with isolated projects enabled will fail fast in settings.gradle.kts
+  // with a helpful error message directing users to use the -D flag.
+  logger.info("Spotless is disabled when isolated projects is enabled. Run spotlessApply directly to format.")
+} else {
+  plugins { id("com.diffplug.spotless") }
+
+  val ktfmtVersion = "0.59"
+
+  val externalFiles =
+    listOf("SkateErrorHandler", "MemoizedSequence", "Publisher", "Resolver").map { "src/**/$it.kt" }
+
+  configure<SpotlessExtension> {
+  format("misc") {
+    target("*.md", ".gitignore")
+    trimTrailingWhitespace()
+    endWithNewline()
+  }
+  kotlin {
+    target("src/**/*.kt")
+    targetExclude(externalFiles)
+    ktfmt(ktfmtVersion).googleStyle()
+    trimTrailingWhitespace()
+    endWithNewline()
+    licenseHeaderFile(rootDir.resolve("spotless/spotless.kt"))
+    targetExclude("**/spotless.kt", "**/Aliases.kt", *externalFiles.toTypedArray())
+  }
+  format("kotlinExternal", KotlinExtension::class.java) {
+    target(externalFiles)
+    ktfmt(ktfmtVersion).googleStyle()
+    trimTrailingWhitespace()
+    endWithNewline()
+    targetExclude("**/spotless.kt", "**/Aliases.kt")
+  }
+  kotlinGradle {
+    target("*.kts", "src/**/*.kts")
+    ktfmt(ktfmtVersion).googleStyle()
+    trimTrailingWhitespace()
+    endWithNewline()
+    licenseHeaderFile(
+      rootDir.resolve("spotless/spotless.kt"),
+      "(import|plugins|buildscript|dependencies|pluginManagement|dependencyResolutionManagement)",
+    )
+  }
+}
+}

--- a/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
@@ -39,7 +39,8 @@ if (isolatedProjectsEnabled) {
 } else {
   plugins { id("com.diffplug.spotless") }
 
-  val ktfmtVersion = "0.59"
+  val catalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+  val ktfmtVersion = catalog.findVersion("ktfmt").get().toString()
 
   val externalFiles =
     listOf("SkateErrorHandler", "MemoizedSequence", "Publisher", "Resolver").map { "src/**/$it.kt" }

--- a/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
+++ b/build-logic/src/main/kotlin/foundry.spotless.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/main/kotlin/foundry/gradle/GitCommitValueSource.kt
+++ b/build-logic/src/main/kotlin/foundry/gradle/GitCommitValueSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/main/kotlin/foundry/gradle/GitCommitValueSource.kt
+++ b/build-logic/src/main/kotlin/foundry/gradle/GitCommitValueSource.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.gradle
+
+import java.util.Locale
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+/** A [ValueSource] that reads the current git commit hash from the .git directory. */
+public abstract class GitCommitValueSource : ValueSource<String, GitCommitValueSource.Params> {
+
+  public interface Params : ValueSourceParameters {
+    public val rootDir: DirectoryProperty
+  }
+
+  override fun obtain(): String? {
+    return try {
+      val gitDir = parameters.rootDir.get().asFile.resolve(".git")
+      val headFile = gitDir.resolve("HEAD")
+      if (!headFile.exists()) return null
+
+      val headContents = headFile.readText(Charsets.UTF_8).lowercase(Locale.US).trim()
+
+      if (isGitHash(headContents)) {
+        return headContents
+      }
+
+      if (!headContents.startsWith("ref:")) {
+        return null
+      }
+
+      val headRef = headContents.removePrefix("ref:").trim()
+      val refFile = gitDir.resolve(headRef)
+      if (!refFile.exists()) {
+        return null
+      }
+
+      refFile.readText(Charsets.UTF_8).trim().takeIf { isGitHash(it) }
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private fun isGitHash(hash: String): Boolean {
+    return hash.length == 40 && hash.all { it in '0'..'9' || it in 'a'..'f' }
+  }
+}

--- a/build-logic/src/test/kotlin/foundry/gradle/GitCommitValueSourceTest.kt
+++ b/build-logic/src/test/kotlin/foundry/gradle/GitCommitValueSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Slack Technologies, LLC
+ * Copyright (C) 2026 Slack Technologies, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build-logic/src/test/kotlin/foundry/gradle/GitCommitValueSourceTest.kt
+++ b/build-logic/src/test/kotlin/foundry/gradle/GitCommitValueSourceTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package foundry.gradle
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GitCommitValueSourceTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun `returns commit hash for valid git repo`() {
+    val gitDir = tempFolder.newFolder("git-repo")
+    gitDir.initGitRepo()
+    gitDir.gitCommit("Initial commit")
+
+    val result = GitCommitValueSource.getGitCommitHash(gitDir)
+
+    assertThat(result).isNotNull()
+    assertThat(result).hasLength(40)
+    assertThat(result).matches("[0-9a-f]{40}")
+  }
+
+  @Test
+  fun `returns null for non-git directory`() {
+    val nonGitDir = tempFolder.newFolder("not-a-repo")
+
+    val result = GitCommitValueSource.getGitCommitHash(nonGitDir)
+
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `returns null for non-existent directory`() {
+    val nonExistentDir = File(tempFolder.root, "does-not-exist")
+
+    val result = GitCommitValueSource.getGitCommitHash(nonExistentDir)
+
+    assertThat(result).isNull()
+  }
+
+  @Test
+  fun `returns correct hash after multiple commits`() {
+    val gitDir = tempFolder.newFolder("multi-commit-repo")
+    gitDir.initGitRepo()
+    gitDir.gitCommit("First commit")
+    val firstHash = GitCommitValueSource.getGitCommitHash(gitDir)
+
+    gitDir.gitCommit("Second commit")
+    val secondHash = GitCommitValueSource.getGitCommitHash(gitDir)
+
+    assertThat(firstHash).isNotNull()
+    assertThat(secondHash).isNotNull()
+    assertThat(firstHash).isNotEqualTo(secondHash)
+  }
+
+  @Test
+  fun `works with packed refs`() {
+    val gitDir = tempFolder.newFolder("packed-refs-repo")
+    gitDir.initGitRepo()
+    gitDir.gitCommit("Initial commit")
+
+    // Pack refs to simulate a cloned repo
+    gitDir.git("gc")
+
+    val result = GitCommitValueSource.getGitCommitHash(gitDir)
+
+    assertThat(result).isNotNull()
+    assertThat(result).hasLength(40)
+  }
+
+  @Test
+  fun `works with detached HEAD`() {
+    val gitDir = tempFolder.newFolder("detached-head-repo")
+    gitDir.initGitRepo()
+    gitDir.gitCommit("First commit")
+    val firstHash = GitCommitValueSource.getGitCommitHash(gitDir)!!
+    gitDir.gitCommit("Second commit")
+
+    // Detach HEAD by checking out a specific commit
+    gitDir.git("checkout", firstHash)
+
+    val result = GitCommitValueSource.getGitCommitHash(gitDir)
+
+    assertThat(result).isEqualTo(firstHash)
+  }
+
+  private fun File.initGitRepo() {
+    git("init")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test User")
+  }
+
+  private fun File.gitCommit(message: String) {
+    // Create or modify a file to have something to commit
+    File(this, "file-${System.nanoTime()}.txt").writeText("content")
+    git("add", ".")
+    git("commit", "-m", message)
+  }
+
+  private fun File.git(vararg args: String) {
+    val process =
+      ProcessBuilder("git", *args)
+        .directory(this)
+        .redirectErrorStream(true)
+        .start()
+    process.waitFor()
+    check(process.exitValue() == 0) {
+      "git ${args.joinToString(" ")} failed: ${process.inputStream.bufferedReader().readText()}"
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,38 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.android.build.api.dsl.Lint
-import com.diffplug.gradle.spotless.KotlinExtension
-import com.diffplug.gradle.spotless.SpotlessExtension
-import com.github.gmazzo.buildconfig.BuildConfigExtension
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import dev.bmac.gradle.intellij.GenerateBlockMapTask
-import dev.bmac.gradle.intellij.PluginUploader
-import dev.bmac.gradle.intellij.UploadPluginTask
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import okio.ByteString.Companion.encode
-import org.gradle.util.internal.VersionNumber
-import org.jetbrains.dokka.gradle.DokkaExtension
-import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
-import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformDependenciesExtension
-import org.jetbrains.intellij.platform.gradle.extensions.IntelliJPlatformExtension
-import org.jetbrains.intellij.platform.gradle.tasks.BuildPluginTask
-import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension
 
 plugins {
+  id("foundry.spotless")
   alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.kotlin.multiplatform) apply false
-  alias(libs.plugins.kotlin.plugin.sam)
+  alias(libs.plugins.kotlin.plugin.sam) apply false
   alias(libs.plugins.detekt)
-  alias(libs.plugins.spotless) apply false
   alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.dokka)
   alias(libs.plugins.ksp) apply false
@@ -55,7 +32,7 @@ plugins {
   alias(libs.plugins.buildConfig) apply false
   alias(libs.plugins.lint) apply false
   alias(libs.plugins.wire) apply false
-  alias(libs.plugins.graphAssert)
+  alias(libs.plugins.graphAssert) apply false
 }
 
 buildscript {
@@ -68,16 +45,40 @@ buildscript {
   }
 }
 
-moduleGraphAssert {
-  // Platforms can depend on tools but not the other way around
-  allowed =
-    arrayOf(
-      ":platforms.* -> :tools.*",
-      ":platforms:gradle.* -> :platforms:gradle.*",
-      ":platforms:intellij.* -> :platforms:intellij.*",
-      ":tools.* -> :tools.*",
+// Several plugins don't support isolated projects and need to be conditionally applied
+val isolatedProjectsEnabled =
+  providers
+    .gradleProperty("org.gradle.unsafe.isolated-projects")
+    .map { it.toBoolean() }
+    .getOrElse(false)
+
+// GraphAssert doesn't support isolated projects as it needs to traverse subproject configurations
+// See: https://github.com/jraska/modules-graph-assert/issues/XXX (TODO: file upstream issue)
+if (!isolatedProjectsEnabled) {
+  apply(plugin = "com.jraska.module.graph.assertion")
+
+  // Use dynamic configuration since the plugin classes aren't on compile classpath with 'apply
+  // false'
+  val ext = extensions.getByName("moduleGraphAssert")
+  val extClass = ext.javaClass
+
+  // Set allowed patterns - platforms can depend on tools but not the other way around
+  extClass
+    .getMethod("setAllowed", Array<String>::class.java)
+    .invoke(
+      ext,
+      arrayOf(
+        ":platforms.* -> :tools.*",
+        ":platforms:gradle.* -> :platforms:gradle.*",
+        ":platforms:intellij.* -> :platforms:intellij.*",
+        ":tools.* -> :tools.*",
+      ),
     )
-  configurations = setOf("api", "implementation")
+
+  // Set configurations to analyze
+  extClass
+    .getMethod("setConfigurations", Set::class.java)
+    .invoke(ext, setOf("api", "implementation"))
 }
 
 configure<DetektExtension> {
@@ -86,52 +87,11 @@ configure<DetektExtension> {
 }
 
 tasks.withType<Detekt>().configureEach {
+  jvmTarget = "21"
   reports {
     html.required.set(true)
     xml.required.set(true)
     txt.required.set(true)
-  }
-}
-
-val ktfmtVersion = libs.versions.ktfmt.get()
-
-val externalFiles =
-  listOf("SkateErrorHandler", "MemoizedSequence", "Publisher", "Resolver").map { "src/**/$it.kt" }
-
-allprojects {
-  apply(plugin = "com.diffplug.spotless")
-  configure<SpotlessExtension> {
-    format("misc") {
-      target("*.md", ".gitignore")
-      trimTrailingWhitespace()
-      endWithNewline()
-    }
-    kotlin {
-      target("src/**/*.kt")
-      targetExclude(externalFiles)
-      ktfmt(ktfmtVersion).googleStyle()
-      trimTrailingWhitespace()
-      endWithNewline()
-      licenseHeaderFile(rootProject.file("spotless/spotless.kt"))
-      targetExclude("**/spotless.kt", "**/Aliases.kt", *externalFiles.toTypedArray())
-    }
-    format("kotlinExternal", KotlinExtension::class.java) {
-      target(externalFiles)
-      ktfmt(ktfmtVersion).googleStyle()
-      trimTrailingWhitespace()
-      endWithNewline()
-      targetExclude("**/spotless.kt", "**/Aliases.kt")
-    }
-    kotlinGradle {
-      target("*.kts", "src/**/*.kts")
-      ktfmt(ktfmtVersion).googleStyle()
-      trimTrailingWhitespace()
-      endWithNewline()
-      licenseHeaderFile(
-        rootProject.file("spotless/spotless.kt"),
-        "(import|plugins|buildscript|dependencies|pluginManagement|dependencyResolutionManagement)",
-      )
-    }
   }
 }
 
@@ -155,275 +115,6 @@ if (!spotlightEnabled) {
     dokka(project(":platforms:gradle:better-gradle-properties"))
     dokka(project(":platforms:gradle:foundry-gradle-plugin"))
     dokka(project(":platforms:gradle:agp-handlers:agp-handler-api"))
-  }
-}
-
-val kotlinVersion = libs.versions.kotlin.get()
-
-val jvmTargetVersion = libs.versions.jvmTarget.map(JvmTarget::fromTarget)
-val jvmTargetIdeaVersion = libs.versions.jvmTargetIdea.map(JvmTarget::fromTarget)
-
-subprojects {
-  project.pluginManager.withPlugin("com.github.gmazzo.buildconfig") {
-    configure<BuildConfigExtension> {
-      buildConfigField("String", "KOTLIN_VERSION", "\"$kotlinVersion\"")
-    }
-  }
-
-  val isForIntelliJPlugin =
-    project.hasProperty("INTELLIJ_PLUGIN") || project.path.startsWith(":platforms:intellij")
-
-  val projectJvmTarget = if (isForIntelliJPlugin) jvmTargetIdeaVersion else jvmTargetVersion
-
-  val isForGradle =
-    project.hasProperty("GRADLE_PLUGIN") || project.path.startsWith(":platforms:gradle")
-  pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-    extensions.configure<KotlinJvmProjectExtension> {
-      if (!isForIntelliJPlugin) {
-        explicitApi()
-      }
-    }
-
-    // Reimplement kotlin-dsl's application of this function for nice DSLs
-    if (isForGradle) {
-      apply(plugin = "kotlin-sam-with-receiver")
-      configure<SamWithReceiverExtension> { annotation("org.gradle.api.HasImplicitReceiver") }
-    }
-
-    apply(plugin = "com.squareup.sort-dependencies")
-  }
-
-  plugins.withType<KotlinBasePlugin>().configureEach {
-    configure<JavaPluginExtension> {
-      toolchain {
-        languageVersion.set(
-          JavaLanguageVersion.of(libs.versions.jdk.get().removeSuffix("-ea").toInt())
-        )
-      }
-    }
-
-    tasks.withType<JavaCompile>().configureEach {
-      options.release.set(projectJvmTarget.map(JvmTarget::target).map(String::toInt))
-    }
-
-    tasks.withType<KotlinCompilationTask<*>>().configureEach {
-      compilerOptions {
-        val kotlinVersion =
-          if (isForIntelliJPlugin) {
-            // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
-            // Note this needs to support the latest stable Studio version.
-            KotlinVersion.KOTLIN_2_0
-          } else if (isForGradle) {
-            // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
-            KotlinVersion.KOTLIN_2_2
-          } else {
-            KotlinVersion.DEFAULT
-          }
-        languageVersion.set(kotlinVersion)
-        apiVersion.set(kotlinVersion)
-
-        if (kotlinVersion != KotlinVersion.DEFAULT) {
-          // Gradle/IntelliJ forces a lower version of kotlin, which results in warnings that
-          // prevent use of this sometimes.
-          // https://github.com/gradle/gradle/issues/16345
-          allWarningsAsErrors.set(false)
-        } else {
-          allWarningsAsErrors.set(true)
-        }
-        if (isForGradle) {
-          // TODO required due to https://github.com/gradle/gradle/issues/24871
-          freeCompilerArgs.addAll("-Xsam-conversions=class", "-Xlambdas=class")
-        }
-        check(this is KotlinJvmCompilerOptions)
-        this.jvmTarget.set(projectJvmTarget)
-        jvmDefault.set(JvmDefaultMode.NO_COMPATIBILITY)
-        freeCompilerArgs.addAll(
-          // Enhance not null annotated type parameter's types to definitely not null types
-          // (@NotNull T => T & Any)
-          "-Xenhance-type-parameter-types-to-def-not-null",
-          "-Xjsr305=strict",
-          // Match JVM assertion behavior:
-          // https://publicobject.com/2019/11/18/kotlins-assert-is-not-like-javas-assert/
-          "-Xassertions=jvm",
-          // Potentially useful for static analysis tools or annotation processors.
-          "-Xemit-jvm-type-annotations",
-          "-Xtype-enhancement-improvements-strict-mode",
-          // https://kotlinlang.org/docs/whatsnew1520.html#support-for-jspecify-nullness-annotations
-          "-Xjspecify-annotations=strict",
-          // https://youtrack.jetbrains.com/issue/KT-73255
-          "-Xannotation-default-target=param-property",
-        )
-        // https://jakewharton.com/kotlins-jdk-release-compatibility-flag/
-        freeCompilerArgs.add(projectJvmTarget.map { "-Xjdk-release=${it.target}" })
-        optIn.addAll(
-          "kotlin.contracts.ExperimentalContracts",
-          "kotlin.experimental.ExperimentalTypeInference",
-          "kotlin.ExperimentalStdlibApi",
-          "kotlin.time.ExperimentalTime",
-        )
-      }
-    }
-
-    tasks.withType<Detekt>().configureEach { this.jvmTarget = projectJvmTarget.get().target }
-  }
-
-  pluginManager.withPlugin("com.vanniktech.maven.publish") {
-    apply(plugin = "org.jetbrains.dokka")
-
-    configure<DokkaExtension> {
-      basePublicationsDirectory.set(layout.buildDirectory.dir("dokkaDir"))
-      dokkaSourceSets.configureEach {
-        documentedVisibilities.add(VisibilityModifier.Public)
-        skipDeprecated.set(true)
-        if (isForGradle) {
-          // Gradle docs
-          externalDocumentationLinks.register("Gradle") {
-            packageListUrl("https://docs.gradle.org/${gradle.gradleVersion}/javadoc/element-list")
-            url("https://docs.gradle.org/${gradle.gradleVersion}/javadoc")
-          }
-          // AGP docs
-          externalDocumentationLinks.register("AGP") {
-            val agpVersionNumber = VersionNumber.parse(libs.versions.agp.get()).baseVersion
-            val simpleApi = "${agpVersionNumber.major}.${agpVersionNumber.minor}"
-            packageListUrl(
-              "https://developer.android.com/reference/tools/gradle-api/$simpleApi/package-list"
-            )
-            url("https://developer.android.com/reference/tools/gradle-api/$simpleApi/classes")
-          }
-        }
-        sourceLink {
-          localDirectory.set(layout.projectDirectory.dir("src"))
-          val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
-          remoteUrl(
-            providers.gradleProperty("POM_SCM_URL").map { scmUrl ->
-              "$scmUrl/tree/main/$relPath/src"
-            }
-          )
-          remoteLineSuffix.set("#L")
-        }
-      }
-    }
-
-    configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(automaticRelease = true, validateDeployment = false)
-      signAllPublications()
-    }
-  }
-
-  if (isForIntelliJPlugin) {
-    project.pluginManager.withPlugin("org.jetbrains.intellij.platform") {
-      data class PluginDetails(
-        val pluginId: String,
-        val name: String,
-        val description: String,
-        val version: String,
-        val sinceBuild: String,
-        val urlSuffix: String,
-      )
-
-      val pluginDetails =
-        PluginDetails(
-          pluginId = property("PLUGIN_ID").toString(),
-          name = property("PLUGIN_NAME").toString(),
-          description = property("PLUGIN_DESCRIPTION").toString(),
-          version = property("VERSION_NAME").toString(),
-          sinceBuild = libs.versions.intellij.sinceBuild.get(),
-          urlSuffix = property("ARTIFACTORY_URL_SUFFIX").toString(),
-        )
-
-      configure<IntelliJPlatformExtension> {
-        pluginConfiguration {
-          id.set(pluginDetails.pluginId)
-          name.set(pluginDetails.name)
-          version.set(pluginDetails.version)
-          description.set(pluginDetails.description)
-          ideaVersion {
-            sinceBuild.set(pluginDetails.sinceBuild)
-            untilBuild.set(project.provider { null })
-          }
-        }
-      }
-      project.dependencies {
-        configure<IntelliJPlatformDependenciesExtension> {
-          // Suppressed deprecation as we can't actually move to intellijIdea() until 2025.3
-          // Bad use of the deprecated annotation
-          @Suppress("DEPRECATION") intellijIdeaCommunity(libs.versions.intellij.version)
-        }
-      }
-
-      if (hasProperty("FoundryIntellijArtifactoryBaseUrl")) {
-        pluginManager.apply(libs.plugins.pluginUploader.get().pluginId)
-        val archive = project.tasks.named<BuildPluginTask>("buildPlugin").flatMap { it.archiveFile }
-        val blockMapTask =
-          tasks.named<GenerateBlockMapTask>(GenerateBlockMapTask.TASK_NAME) {
-            notCompatibleWithConfigurationCache(
-              "Blockmap generation is not compatible with the configuration cache"
-            )
-            file.set(archive)
-            blockmapFile.set(
-              project.layout.buildDirectory.file(
-                "blockmap/blockmap${GenerateBlockMapTask.BLOCKMAP_FILE_SUFFIX}"
-              )
-            )
-            blockmapHashFile.set(
-              project.layout.buildDirectory.file(
-                "blockmap/blockmap${GenerateBlockMapTask.HASH_FILE_SUFFIX}"
-              )
-            )
-          }
-
-        // Get the plugin distribution file from the signPlugin task provided from the
-        // gradle-intellij-plugin
-        tasks.register<UploadPluginTask>("uploadPluginToArtifactory") {
-          notCompatibleWithConfigurationCache(
-            "UploadPluginTask is not compatible with the configuration cache"
-          )
-          // TODO why doesn't the flatmap below automatically handle this dependency?
-          dependsOn(blockMapTask)
-          blockmapFile.set(blockMapTask.flatMap { it.blockmapFile })
-          blockmapHashFile.set(blockMapTask.flatMap { it.blockmapHashFile })
-          url.set(
-            providers.gradleProperty("FoundryIntellijArtifactoryBaseUrl").map { baseUrl ->
-              "$baseUrl/${pluginDetails.urlSuffix}"
-            }
-          )
-          pluginName.set(pluginDetails.name)
-          file.set(archive)
-          repoType.set(PluginUploader.RepoType.REST_PUT)
-          pluginId.set(pluginDetails.pluginId)
-          version.set(pluginDetails.version)
-          pluginDescription.set(pluginDetails.description)
-          val changeNotesFile = file("change-notes.html")
-          if (changeNotesFile.exists()) {
-            changeNotes.set(changeNotesFile.readText())
-          }
-          sinceBuild.set(pluginDetails.sinceBuild)
-          authentication.set(
-            // Zip the username and token together to create an appropriate encoded auth header
-            providers.gradleProperty("FoundryIntellijArtifactoryUsername").zip(
-              providers.gradleProperty("FoundryIntellijArtifactoryToken")
-            ) { username, token ->
-              "Basic ${"$username:$token".encode().base64()}"
-            }
-          )
-        }
-      }
-    }
-  }
-
-  pluginManager.withPlugin("com.android.lint") {
-    configure<Lint> {
-      lintConfig = rootProject.layout.projectDirectory.file("config/lint/lint.xml").asFile
-      baseline = project.layout.projectDirectory.file("lint-baseline.xml").asFile
-    }
-    project.dependencies.add("lintChecks", libs.slackLints.checks)
-    val configToAdd =
-      if (pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
-        "jvmMainCompileOnly"
-      } else {
-        "compileOnly"
-      }
-    afterEvaluate { project.dependencies.add(configToAdd, libs.slackLints.annotations) }
   }
 }
 

--- a/docs/platforms/gradle/formatters-and-analysis.md
+++ b/docs/platforms/gradle/formatters-and-analysis.md
@@ -20,8 +20,8 @@ The core set of formatters are:
 If the project has Gradle's isolated projects feature enabled (`org.gradle.unsafe.isolated-projects=true`), you must disable it when running Spotless tasks:
 
 ```bash
-./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
-./gradlew spotlessCheck -Dorg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessApply -Porg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessCheck -Porg.gradle.unsafe.isolated-projects=false
 ```
 
 This is required because Spotless does not yet support isolated projects. See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for tracking.

--- a/docs/platforms/gradle/formatters-and-analysis.md
+++ b/docs/platforms/gradle/formatters-and-analysis.md
@@ -15,6 +15,17 @@ The core set of formatters are:
 - gradle-dependency-sorter (Gradle build file dependencies)
 - Spotless (general purpose Gradle plugin that runs most of the above)
 
+### Running Spotless with Isolated Projects
+
+If the project has Gradle's isolated projects feature enabled (`org.gradle.unsafe.isolated-projects=true`), you must disable it when running Spotless tasks:
+
+```bash
+./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessCheck -Dorg.gradle.unsafe.isolated-projects=false
+```
+
+This is required because Spotless does not yet support isolated projects. See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for tracking.
+
 ## Static Analysis
 
 The core set of analysis tools supported in Foundry are:

--- a/docs/platforms/gradle/formatters-and-analysis.md
+++ b/docs/platforms/gradle/formatters-and-analysis.md
@@ -20,8 +20,8 @@ The core set of formatters are:
 If the project has Gradle's isolated projects feature enabled (`org.gradle.unsafe.isolated-projects=true`), you must disable it when running Spotless tasks:
 
 ```bash
-./gradlew spotlessApply -Porg.gradle.unsafe.isolated-projects=false
-./gradlew spotlessCheck -Porg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
+./gradlew spotlessCheck -Dorg.gradle.unsafe.isolated-projects=false
 ```
 
 This is required because Spotless does not yet support isolated projects. See [diffplug/spotless#1979](https://github.com/diffplug/spotless/issues/1979) for tracking.

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -15,12 +15,26 @@ dependencies {
 @file:DependsOn("com.slack.foundry:cli:{version}")
 ```
 
+## Building
+
+This project uses Gradle's isolated projects feature by default. However, the CLI module uses KSP
+(Kotlin Symbol Processing) for `@AutoService` annotations to generate service loader files for
+command discovery. Since KSP does not yet support isolated projects, you must disable it when
+building the CLI:
+
+```bash
+./gradlew :tools:cli:build -Porg.gradle.unsafe.isolated-projects=false
+```
+
+Without this flag, the CLI JAR will not contain the service loader files and CLI commands will not
+be discoverable at runtime.
+
 ## Local testing
 
 If consuming these utilities from a kotlin script file, you can test changes like so:
 
 1. Set the version in `gradle.properties`, such as `2.5.0-LOCAL1`.
-2. Run `./gradlew publishToMavenLocal` to publish the current version to your local maven repository.
+2. Run `./gradlew publishToMavenLocal -Porg.gradle.unsafe.isolated-projects=false` to publish the current version to your local maven repository.
 3. In your script file, add the local repository and update the version:
     ```kotlin
     @file:Repository("file:///Users/{username}/.m2/repository")

--- a/docs/tools/cli.md
+++ b/docs/tools/cli.md
@@ -23,7 +23,7 @@ command discovery. Since KSP does not yet support isolated projects, you must di
 building the CLI:
 
 ```bash
-./gradlew :tools:cli:build -Porg.gradle.unsafe.isolated-projects=false
+./gradlew :tools:cli:build -Dorg.gradle.unsafe.isolated-projects=false
 ```
 
 Without this flag, the CLI JAR will not contain the service loader files and CLI commands will not
@@ -34,7 +34,7 @@ be discoverable at runtime.
 If consuming these utilities from a kotlin script file, you can test changes like so:
 
 1. Set the version in `gradle.properties`, such as `2.5.0-LOCAL1`.
-2. Run `./gradlew publishToMavenLocal -Porg.gradle.unsafe.isolated-projects=false` to publish the current version to your local maven repository.
+2. Run `./gradlew publishToMavenLocal -Dorg.gradle.unsafe.isolated-projects=false` to publish the current version to your local maven repository.
 3. In your script file, add the local repository and update the version:
     ```kotlin
     @file:Repository("file:///Users/{username}/.m2/repository")

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.unsafe.isolated-projects=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.jetbrains.intellij.platform.useCacheRedirector=false
 

--- a/platforms/gradle/agp-handlers/agp-handler-api/build.gradle.kts
+++ b/platforms/gradle/agp-handlers/agp-handler-api/build.gradle.kts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm-gradle")
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.lint)
 }

--- a/platforms/gradle/foundry-gradle-plugin/build.gradle.kts
+++ b/platforms/gradle/foundry-gradle-plugin/build.gradle.kts
@@ -16,7 +16,8 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
-  kotlin("jvm")
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm-gradle")
   `java-gradle-plugin`
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.bestPracticesPlugin)
@@ -47,13 +48,15 @@ buildConfig {
 
 // Copy our hooks into resources for InstallCommitHooks
 tasks.named<ProcessResources>("processResources") {
-  from(rootProject.layout.projectDirectory.dir("config/git/hooks")) {
+  from(rootDir.resolve("config/git/hooks")) {
     // Give it a common prefix for us to look for
     rename { name -> "githook-$name" }
   }
 }
 
 moshi { enableSealed.set(true) }
+
+lint { baseline = file("lint-baseline.xml") }
 
 tasks.named<ValidatePlugins>("validatePlugins") { enableStricterValidation.set(true) }
 

--- a/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
+++ b/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
@@ -135,39 +135,6 @@
 
     <issue
         id="GradleProjectIsolation"
-        message="Use providers.gradleProperty instead of findProperty"
-        errorLine1="      (findProperty(AndroidProject.PROPERTY_BUILD_MODEL_ONLY) == &quot;true&quot; ||"
-        errorLine2="       ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="230"
-            column="8"/>
-    </issue>
-
-    <issue
-        id="GradleProjectIsolation"
-        message="Use providers.gradleProperty instead of findProperty"
-        errorLine1="        findProperty(AndroidProject.PROPERTY_GENERATE_SOURCES_ONLY) == &quot;true&quot;)"
-        errorLine2="        ~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="231"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="GradleProjectIsolation"
-        message="Use providers.gradleProperty instead of hasProperty"
-        errorLine1="  get() = hasProperty(&quot;android.injected.invoked.from.ide&quot;)"
-        errorLine2="          ~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="235"
-            column="11"/>
-    </issue>
-
-    <issue
-        id="GradleProjectIsolation"
         message="Avoid using method getRootProject"
         errorLine1="      lintConfig = rootProject.layout.projectDirectory.file(&quot;config/lint/lint.xml&quot;).asFile"
         errorLine2="                   ~~~~~~~~~~~">
@@ -373,39 +340,6 @@
             file="src/main/kotlin/foundry/gradle/tasks/ProgressResponseBody.kt"
             line="26"
             column="1"/>
-    </issue>
-
-    <issue
-        id="WithTypeWithoutConfigureEach"
-        message="Avoid passing a closure to withType, use withType().configureEach instead"
-        errorLine1="        project.tasks.withType("
-        errorLine2="                      ~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/AnnotationProcessing.kt"
-            line="143"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="WithTypeWithoutConfigureEach"
-        message="Avoid passing a closure to withType, use withType().configureEach instead"
-        errorLine1="    project.plugins.withType(AppPlugin::class.java) {"
-        errorLine2="                    ~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/ApkVersioningPlugin.kt"
-            line="50"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="WithTypeWithoutConfigureEach"
-        message="Avoid passing a closure to withType, use withType().configureEach instead"
-        errorLine1="  tasks.withType(T::class.java) {"
-        errorLine2="        ~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt"
-            line="244"
-            column="9"/>
     </issue>
 
 </issues>

--- a/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
+++ b/platforms/gradle/foundry-gradle-plugin/lint-baseline.xml
@@ -1,104 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.11.0-alpha10" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.1)" variant="all" version="8.11.0-alpha10">
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="  val segmentName = this::class.simpleName!!"
-        errorLine2="                                          ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/dependencies/DependencyCollection.kt"
-            line="111"
-            column="43"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="    gradleProperty ?: this::class.simpleName!!.lowercase(Locale.US)"
-        errorLine2="                                            ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/dependencies/DependencyGroup.kt"
-            line="43"
-            column="45"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="                    var newConfiguration = advice.toConfiguration!!"
-        errorLine2="                                                                 ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
-            line="235"
-            column="66"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="              val oldConfiguration = abiDep.fromConfiguration!!"
-        errorLine2="                                                             ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
-            line="304"
-            column="62"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="              var newConfiguration = abiDep.toConfiguration!!"
-        errorLine2="                                                           ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/dependencyrake/DependencyRake.kt"
-            line="305"
-            column="60"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="    androidExtension!!.testOptions.unitTests.isIncludeAndroidResources = true"
-        errorLine2="                    ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/FoundryExtension.kt"
-            line="1146"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="    optionalStringProperty(key, defaultValue)!!"
-        errorLine2="                                             ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/FoundryProperties.kt"
-            line="72"
-            column="46"/>
-    </issue>
-
-    <issue
-        id="AvoidUsingNotNullOperator"
-        message="Avoid using the `!!` operator"
-        errorLine1="      Publisher.interProjectPublisher(project, artifact.objectInstance!!)"
-        errorLine2="                                                                      ~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt"
-            line="138"
-            column="71"/>
-    </issue>
-
-    <issue
-        id="MoshiUsageNonMoshiClassMap"
-        message="Concrete Map type &apos;RegexMap&apos; is not natively supported by Moshi."
-        errorLine1="  val replacementPatterns: RegexMap = RegexMap(),"
-        errorLine2="                           ~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/topography/ModuleFeature.kt"
-            line="26"
-            column="28"/>
-    </issue>
+<issues format="6" by="lint 8.13.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.2)" variant="all" version="8.13.2">
 
     <issue
         id="GradleProjectIsolation"
@@ -184,7 +85,7 @@
         errorLine2="                                      ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryProperties.kt"
-            line="968"
+            line="973"
             column="39"/>
     </issue>
 
@@ -206,7 +107,7 @@
         errorLine2="             ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/FoundryRootPlugin.kt"
-            line="384"
+            line="377"
             column="14"/>
     </issue>
 
@@ -239,7 +140,7 @@
         errorLine2="       ~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="240"
+            line="230"
             column="8"/>
     </issue>
 
@@ -250,7 +151,7 @@
         errorLine2="        ~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="241"
+            line="231"
             column="9"/>
     </issue>
 
@@ -261,7 +162,7 @@
         errorLine2="          ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/foundry/gradle/GradleExt.kt"
-            line="245"
+            line="235"
             column="11"/>
     </issue>
 
@@ -285,28 +186,6 @@
             file="src/main/kotlin/foundry/gradle/testing/UnitTests.kt"
             line="234"
             column="29"/>
-    </issue>
-
-    <issue
-        id="InternalAgpApiUsage"
-        message="Avoid using internal Android Gradle Plugin APIs"
-        errorLine1="import com.android.build.gradle.internal.SdkLocationSourceSet"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/AndroidSourcesConfigurer.kt"
-            line="18"
-            column="1"/>
-    </issue>
-
-    <issue
-        id="InternalAgpApiUsage"
-        message="Avoid using internal Android Gradle Plugin APIs"
-        errorLine1="import com.android.build.gradle.internal.SdkLocator"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/AndroidSourcesConfigurer.kt"
-            line="19"
-            column="1"/>
     </issue>
 
     <issue
@@ -527,39 +406,6 @@
             file="src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt"
             line="244"
             column="9"/>
-    </issue>
-
-    <issue
-        id="ExceptionMessage"
-        message="Please specify a `lazyMessage` param for require"
-        errorLine1="            add(&quot;api&quot;, def.coordinates) { version { require(version) } }"
-        errorLine2="                                                    ~~~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/Platforms.kt"
-            line="183"
-            column="53"/>
-    </issue>
-
-    <issue
-        id="ExceptionMessage"
-        message="Please specify a `lazyMessage` param for check"
-        errorLine1="    check(logs.isNotEmpty())"
-        errorLine2="    ~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/util/ThermalsWatcher.kt"
-            line="216"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="ExceptionMessage"
-        message="Please specify a `lazyMessage` param for check"
-        errorLine1="    check(logs.isNotEmpty())"
-        errorLine2="    ~~~~~">
-        <location
-            file="src/main/kotlin/foundry/gradle/util/ThermalsWatcher.kt"
-            line="216"
-            column="5"/>
     </issue>
 
 </issues>

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
@@ -140,9 +140,8 @@ internal abstract class BasicAptOptionsConfig : AptOptionsConfig {
         project.logger.debug(
           "${baseConfig.name}: Adding javac apt options to android project ${project.path}"
         )
-        project.tasks.withType(
-          JavaCompile::class.java,
-          baseConfig.javaCompileAptAction(foundryProperties),
+        project.tasks.withType(JavaCompile::class.java).configureEach(
+          baseConfig.javaCompileAptAction(foundryProperties)
         )
       }
 

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/AnnotationProcessing.kt
@@ -140,9 +140,9 @@ internal abstract class BasicAptOptionsConfig : AptOptionsConfig {
         project.logger.debug(
           "${baseConfig.name}: Adding javac apt options to android project ${project.path}"
         )
-        project.tasks.withType(JavaCompile::class.java).configureEach(
-          baseConfig.javaCompileAptAction(foundryProperties)
-        )
+        project.tasks
+          .withType(JavaCompile::class.java)
+          .configureEach(baseConfig.javaCompileAptAction(foundryProperties))
       }
 
     override fun configure(configurationContext: ConfigurationContext) =

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/ApkVersioningPlugin.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/ApkVersioningPlugin.kt
@@ -47,7 +47,7 @@ internal class ApkVersioningPlugin : Plugin<Project> {
 
   @Suppress("LongMethod")
   override fun apply(project: Project) {
-    project.plugins.withType(AppPlugin::class.java) {
+    project.plugins.withType(AppPlugin::class.java).configureEach {
       val versionMajor = project.localGradleProperty("versionMajor")
       val versionMinor = project.localGradleProperty("versionMinor")
       val versionPatch = project.localGradleProperty("versionPatch")

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
@@ -241,7 +241,7 @@ internal inline fun <reified T : Task> Project.namedLazy(
 
   var didRun = false
 
-  tasks.withType(T::class.java) {
+  tasks.withType(T::class.java).configureEach {
     if (name == targetName) {
       action(tasks.named(name, T::class.java))
       didRun = true

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/GradleExt.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/GradleExt.kt
@@ -227,12 +227,12 @@ internal value class OnceCheck(val once: AtomicBoolean = AtomicBoolean(false)) {
 public val Project.isSyncing: Boolean
   get() =
     invokedFromIde &&
-      (findProperty(AndroidProject.PROPERTY_BUILD_MODEL_ONLY) == "true" ||
-        findProperty(AndroidProject.PROPERTY_GENERATE_SOURCES_ONLY) == "true")
+      (providers.gradleProperty(AndroidProject.PROPERTY_BUILD_MODEL_ONLY).orNull == "true" ||
+        providers.gradleProperty(AndroidProject.PROPERTY_GENERATE_SOURCES_ONLY).orNull == "true")
 
 // Note that we don't reference the AndroidProject property because this constant moved in AGP 7.2
 public val Project.invokedFromIde: Boolean
-  get() = hasProperty("android.injected.invoked.from.ide")
+  get() = providers.gradleProperty("android.injected.invoked.from.ide").isPresent
 
 internal inline fun <reified T : Any> ObjectFactory.newInstance(vararg parameters: Any): T {
   return newInstance(T::class.java, *parameters)

--- a/platforms/intellij/compose/build.gradle.kts
+++ b/platforms/intellij/compose/build.gradle.kts
@@ -16,6 +16,7 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
+  id("foundry.spotless")
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.buildConfig)
   alias(libs.plugins.compose)
@@ -24,7 +25,7 @@ plugins {
 }
 
 kotlin {
-  jvm()
+  jvm { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
   sourceSets {
     jvmMain {

--- a/platforms/intellij/compose/playground/build.gradle.kts
+++ b/platforms/intellij/compose/playground/build.gradle.kts
@@ -16,6 +16,7 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
+  id("foundry.spotless")
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.compose)
   alias(libs.plugins.kotlin.plugin.compose)
@@ -32,7 +33,7 @@ roborazzi {
 }
 
 kotlin {
-  jvm()
+  jvm { compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21) } }
 
   sourceSets {
     jvmMain {

--- a/release.sh
+++ b/release.sh
@@ -16,7 +16,7 @@ git tag -a "$NEW_VERSION" -m "Version $NEW_VERSION"
 
 # Publish
 # Disable isolated projects because CLI module requires KSP for service loader generation
-./gradlew publish --no-configuration-cache -Porg.gradle.unsafe.isolated-projects=false -PSONATYPE_CONNECT_TIMEOUT_SECONDS=300 -Dspotlight.enabled=false
+./gradlew publish --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false -PSONATYPE_CONNECT_TIMEOUT_SECONDS=300 -Dspotlight.enabled=false
 
 # Prepare next snapshot
 echo "Restoring snapshot version $SNAPSHOT_VERSION"

--- a/release.sh
+++ b/release.sh
@@ -15,7 +15,8 @@ git commit -am "Prepare for release $NEW_VERSION."
 git tag -a "$NEW_VERSION" -m "Version $NEW_VERSION"
 
 # Publish
-./gradlew publish --no-configuration-cache -PSONATYPE_CONNECT_TIMEOUT_SECONDS=300 -Dspotlight.enabled=false
+# Disable isolated projects because CLI module requires KSP for service loader generation
+./gradlew publish --no-configuration-cache -Porg.gradle.unsafe.isolated-projects=false -PSONATYPE_CONNECT_TIMEOUT_SECONDS=300 -Dspotlight.enabled=false
 
 # Prepare next snapshot
 echo "Restoring snapshot version $SNAPSHOT_VERSION"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,39 @@
  */
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 
+// Automatically detect spotless tasks and provide guidance for isolated projects
+// This is necessary because Spotless doesn't support isolated projects
+// See: https://github.com/diffplug/spotless/issues/1979
+val requestedTasks = gradle.startParameter.taskNames
+val isSpotlessTask = requestedTasks.any { task -> task.contains("spotless", ignoreCase = true) }
+
+// Check if isolated projects is enabled (system property from -D flag takes precedence)
+val isolatedProjectsFromGradleProperty =
+  providers
+    .gradleProperty("org.gradle.unsafe.isolated-projects")
+    .map { it.toBoolean() }
+    .getOrElse(false)
+val isolatedProjectsFromSystemProperty =
+  providers.systemProperty("org.gradle.unsafe.isolated-projects").map { it.toBoolean() }.orNull
+val isolatedProjectsEnabled =
+  isolatedProjectsFromSystemProperty ?: isolatedProjectsFromGradleProperty
+
+if (isSpotlessTask && isolatedProjectsEnabled) {
+  // Fail fast with a helpful error message
+  throw GradleException(
+    """
+    |
+    |Spotless tasks cannot run with isolated projects enabled.
+    |Spotless does not support isolated projects: https://github.com/diffplug/spotless/issues/1979
+    |
+    |To run spotless, use one of these options:
+    |  ./gradlew spotlessApply -Dorg.gradle.unsafe.isolated-projects=false
+    |  ./gradlew spotlessCheck -Dorg.gradle.unsafe.isolated-projects=false
+    |"""
+      .trimMargin()
+  )
+}
+
 pluginManagement {
   // Non-delegate APIs are annoyingly not public so we have to use withGroovyBuilder
   fun hasProperty(key: String): Boolean {
@@ -75,6 +108,8 @@ plugins {
   // https://github.com/joshfriend/spotlight
   id("com.fueledbycaffeine.spotlight") version "1.4.1"
 }
+
+includeBuild("build-logic")
 
 dependencyResolutionManagement {
   versionCatalogs {

--- a/tools/cli/build.gradle.kts
+++ b/tools/cli/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 // KSP doesn't support isolated projects yet
@@ -39,9 +38,6 @@ plugins {
 if (!isolatedProjectsEnabled) {
   apply(plugin = "com.google.devtools.ksp")
 }
-
-// Configure detekt jvmTarget (detekt doesn't support JDK 23 yet)
-tasks.withType<Detekt>().configureEach { jvmTarget = "21" }
 
 kotlin {
   @OptIn(ExperimentalAbiValidation::class) abiValidation { enabled.set(true) }

--- a/tools/cli/build.gradle.kts
+++ b/tools/cli/build.gradle.kts
@@ -16,7 +16,7 @@
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 // KSP doesn't support isolated projects yet
-// See: https://github.com/google/ksp/issues/XXXX (TODO: file upstream issue)
+// See: https://github.com/google/ksp/issues/1943
 val isolatedProjectsEnabled =
   providers
     .gradleProperty("org.gradle.unsafe.isolated-projects")

--- a/tools/foundry-common/build.gradle.kts
+++ b/tools/foundry-common/build.gradle.kts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm")
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.lint)
 }

--- a/tools/robolectric-sdk-management/build.gradle.kts
+++ b/tools/robolectric-sdk-management/build.gradle.kts
@@ -13,12 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import io.gitlab.arturbosch.detekt.Detekt
+
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm")
   alias(libs.plugins.dokka)
   alias(libs.plugins.detekt)
   alias(libs.plugins.lint)
   alias(libs.plugins.mavenPublish)
 }
+
+// Configure detekt jvmTarget (detekt doesn't support JDK 23 yet)
+tasks.withType<Detekt>().configureEach { jvmTarget = "21" }
 
 dependencies { implementation(libs.robolectric) }

--- a/tools/robolectric-sdk-management/build.gradle.kts
+++ b/tools/robolectric-sdk-management/build.gradle.kts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.gitlab.arturbosch.detekt.Detekt
-
 plugins {
   id("foundry.spotless")
   id("foundry.kotlin-jvm")
@@ -23,8 +21,5 @@ plugins {
   alias(libs.plugins.lint)
   alias(libs.plugins.mavenPublish)
 }
-
-// Configure detekt jvmTarget (detekt doesn't support JDK 23 yet)
-tasks.withType<Detekt>().configureEach { jvmTarget = "21" }
 
 dependencies { implementation(libs.robolectric) }

--- a/tools/skippy/build.gradle.kts
+++ b/tools/skippy/build.gradle.kts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm")
   alias(libs.plugins.moshix)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.lint)

--- a/tools/tracing/build.gradle.kts
+++ b/tools/tracing/build.gradle.kts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm")
   alias(libs.plugins.wire)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.lint)

--- a/tools/version-number/build.gradle.kts
+++ b/tools/version-number/build.gradle.kts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  alias(libs.plugins.kotlin.jvm)
+  id("foundry.spotless")
+  id("foundry.kotlin-jvm")
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.lint)
 }


### PR DESCRIPTION
This PR enables Gradle's https://docs.gradle.org/current/userguide/isolated_projects.html feature (org.gradle.unsafe.isolated-projects=true), which allows Gradle to parallelize project configuration and improve configuration caching. So far I have the codebase building correctly with it, but I still need to do some testing to make sure I haven't created any breaking changes for consumers of the plugin.