### PR TITLE
chore: gitignore Claude Code local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ temp-clone/
 
 # Files generated for Spotlight: https://github.com/joshfriend/spotlight
 gradle/ide-projects.txt
+
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Ignore `.claude/worktrees/` — temporary git worktrees created by Claude Code agents
- Ignore `.claude/settings.local.json` — machine-specific local settings

## Why

These files are generated locally by Claude Code and are not meant to be shared or committed. Adding them to `.gitignore` prevents accidental inclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)