### PR TITLE
Fix `composeRuntimeOnly()` crashing project configuration

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -958,7 +958,7 @@ constructor(
 
       // composeRuntimeOnly() skips applying kotlin.plugin.compose, so the compiler extension
       // below won't exist — short-circuit before reading it.
-      if (!enableCompiler.get()) return
+      if (!enableCompiler.getOrElse(false)) return
 
       val extension = project.extensions.getByType<ComposeCompilerGradlePluginExtension>()
       if (foundryProperties.composeGlobalStabilityConfigurationPath.isPresent) {

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryExtension.kt
@@ -956,6 +956,10 @@ constructor(
         composeBundleAlias?.let { project.dependencies.add("implementation", it) }
       }
 
+      // composeRuntimeOnly() skips applying kotlin.plugin.compose, so the compiler extension
+      // below won't exist — short-circuit before reading it.
+      if (!enableCompiler.get()) return
+
       val extension = project.extensions.getByType<ComposeCompilerGradlePluginExtension>()
       if (foundryProperties.composeGlobalStabilityConfigurationPath.isPresent) {
         extension.stabilityConfigurationFiles.add(


### PR DESCRIPTION
## Summary

`composeRuntimeOnly()` crashes project configuration with `Extension of type 'ComposeCompilerGradlePluginExtension' does not exist`. This PR adds a small guard that makes the API usable.

## Root cause

`ComposeHandler.applyTo` looks up the Compose Compiler extension unconditionally:

```kotlin
internal fun applyTo(project: Project) {
  if (enabled.get()) {
    // …runtime-artifact wiring (used by both compose() and composeRuntimeOnly())…

    val extension = project.extensions.getByType<ComposeCompilerGradlePluginExtension>()
    // …configure compiler-only options on `extension`…
  }
}
```

`composeRuntimeOnly()` calls `enable(..., enableCompiler = false)`, which deliberately does **not** apply `org.jetbrains.kotlin.plugin.compose`. The compiler extension is never registered, so the `getByType` lookup throws at configuration time.

## Fix

Short-circuit before the extension lookup when `enableCompiler` is false:

```kotlin
if (!enableCompiler.get()) return

val extension = project.extensions.getByType<ComposeCompilerGradlePluginExtension>()
```

The runtime-artifact wiring above the guard still runs, so callers get the compose-runtime dependency wired correctly without paying for the compiler plugin.

## Why this matters

Modules that consume Compose runtime types (`@Stable`, `@Immutable`, `Snapshot`, etc.) without authoring `@Composable` functions don't need the compiler. `composeRuntimeOnly()` is the documented API for that case, but it's currently unusable.

## Test plan

- [x] Verified end-to-end via `includeBuild` against a downstream consumer: switching a real module from the manual workaround to `foundry { features { composeRuntimeOnly() } }` configures and compiles cleanly with this fix; reverting to `main` reproduces the original throw.