### PR TITLE
fix: avoid "androidTestImplementation dependencies are ignored" warning

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/Configurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/Configurations.kt
@@ -28,6 +28,13 @@ internal object Configurations {
 
   fun isTest(name: String): Boolean = testConfigurationRegex.matches(name)
 
+  /**
+   * Whether [name] is an android instrumentation test ("androidTest") configuration, such as
+   * `androidTestImplementation` or `androidTestUtil`. Note this intentionally does not match unit
+   * test configurations like `testImplementation`.
+   */
+  fun isAndroidTest(name: String): Boolean = name.contains("androidTest", ignoreCase = true)
+
   fun isApi(name: String): Boolean = name.endsWith("api", ignoreCase = true)
 
   object ErrorProne {

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -201,7 +201,7 @@ internal class StandardProjectConfigurations(
         )
       }
     } else if (!foundryProperties.noPlatform && path != platformProjectPath) {
-      applyPlatforms(foundryProperties.versions.boms, platformProjectPath)
+      applyPlatforms(foundryProperties.versions.boms, platformProjectPath, foundryExtension)
     }
 
     checkAndroidXDependencies(foundryProperties)
@@ -284,6 +284,7 @@ internal class StandardProjectConfigurations(
   private fun Project.applyPlatforms(
     boms: Set<Provider<MinimalExternalModuleDependency>>,
     platformProject: String,
+    foundryExtension: FoundryExtension,
   ) {
     configurations.configureEach {
       if (Configurations.isTest(name) && Configurations.isApi(name)) {
@@ -291,6 +292,17 @@ internal class StandardProjectConfigurations(
         // https://youtrack.jetbrains.com/issue/KT-61653
         project.logger.debug("Ignoring boms on ${project.path}:$name")
         return@configureEach
+      }
+      if (Configurations.isAndroidTest(name)) {
+        // Only platform androidTest* configurations when the androidTest variant is enabled.
+        // Otherwise AGP ignores the dependencies and warns, since libraries don't opt into
+        // androidTest by default.
+        val androidTestEnabled =
+          foundryExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
+        if (!androidTestEnabled) {
+          project.logger.debug("Ignoring boms on ${project.path}:$name (androidTest disabled)")
+          return@configureEach
+        }
       }
       if (isPlatformConfigurationName(name)) {
         project.logger.debug("Adding boms to ${project.path}:$name")


### PR DESCRIPTION
## Problem

Library modules emit this warning at configuration time, once each, for nearly every Android library in a consuming project:

```
WARNING: androidTestImplementation dependencies are ignored because androidTest is disabled.
```

It fires even for modules that declare no `androidTest` dependencies of their own, which points at the convention plugin injecting them.

## Cause

The source is `applyPlatforms()`: it adds platform BOM dependencies to every configuration for which `isPlatformConfigurationName()` returns `true`. That matcher does **suffix** matching against the `RUNTIME` group, which contains `"implementation"`. Since `"androidTestImplementation"` ends with `"implementation"`, Foundry was platforming the `androidTestImplementation` configuration of every Android module.

Library modules do not enable the androidTest variant by default (it is opt-in via the `androidTest()` feature). When the variant is disabled, AGP ignores anything added to the `androidTest*` configurations and warns, hence the noise across the whole project.

## Fix

In `applyPlatforms()`, skip platforming `androidTest*` configurations (new `Configurations.isAndroidTest()` helper) unless the androidTest feature is enabled for the project. Modules that do opt into androidTest are unaffected and still get their platform dependencies.

## Verification

Tested against a large internal consumer via a composite build (`--rerun-tasks`, configuration cache disabled):

| Scenario | `androidTestImplementation ... ignored` warnings | Build |
|---|---|---|
| Library module, before fix | 23 | SUCCESSFUL |
| Same library module, after fix | 0 | SUCCESSFUL |
| androidTest-enabled module, after fix | 0 (no regression) | SUCCESSFUL |
