### PR TITLE
Add `Project.androidTestProjectPaths()` accessor for androidTest projects

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/FoundryGradleUtil.kt
@@ -19,6 +19,8 @@ import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.api.variant.TestAndroidComponentsExtension
+import foundry.gradle.artifacts.FoundryArtifact
+import foundry.gradle.artifacts.Resolver
 import foundry.gradle.properties.gitExecProvider
 import foundry.gradle.properties.mapToBoolean
 import java.io.File
@@ -33,6 +35,7 @@ import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.TaskContainer
@@ -127,6 +130,33 @@ public fun Project.fullGitShaProvider(): Provider<String> {
 
 public fun Project.gitShaProvider(): Provider<String> {
   return providers.gitExecProvider("git", "rev-parse", "--short", "HEAD")
+}
+
+/**
+ * Returns the distinct paths of projects that produce androidTest APKs. Resolves eagerly from
+ * published metadata, reading only each artifact's owning project (not its files), so it is safe to
+ * call at configuration time and does not trigger the producer tasks. Must be called on the root
+ * project after Foundry's root plugin is applied.
+ */
+public fun Project.androidTestProjectPaths(): List<String> {
+  val configurationName =
+    Resolver.resolvableConfigurationName(FoundryArtifact.SkippyAndroidTestProject.declarableName)
+  val configuration =
+    configurations.findByName(configurationName)
+      ?: error(
+        "Configuration '$configurationName' not found. androidTestProjectPaths() must be called on " +
+          "the root project after Foundry's root plugin is applied, which registers the resolver " +
+          "this reads from."
+      )
+  // Only projects that publish the androidTest artifact match the view's attributes, so this is
+  // exactly the producer set.
+  return configuration.incoming
+    .artifactView { lenient(true) }
+    .artifacts
+    .resolvedArtifacts
+    .get()
+    .mapNotNull { (it.id.componentIdentifier as? ProjectComponentIdentifier)?.projectPath }
+    .distinct()
 }
 
 public val Project.ciBuildNumber: Provider<String>

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -638,30 +638,20 @@ internal class StandardProjectConfigurations(
               }
 
               if (isAffectedProject) {
-                // Aggregate test apks. In Fladle we aggregate test APKs, in emulator.wtf we
-                // aggregate
-                // to their root project dep
-                if (foundryProperties.enableEmulatorWtfForAndroidTest) {
-                  // Aggregate to emulator.wtf's configuration instead
-                  // TODO this doesn't work yet, toe-hold for the future
-                  // @Suppress("GradleProjectIsolation")
-                  // project.rootProject.dependencies.add(
-                  //   "emulatorwtf",
-                  //   project.rootProject.project(project.path),
-                  // )
-                } else {
-                  // Note this intentionally just uses the same task each time as they always
-                  // produce
-                  // the same output
-                  SimpleFileProducerTask.registerOrConfigure(
-                      project,
-                      name = "androidTestProjectMetadata",
-                      description =
-                        "Produces a metadata artifact indicating this project path produces an androidTest APK.",
-                      input = projectPath,
-                      group = "skippy",
-                    )
-                    .publishWith(skippyAndroidTestProjectPublisher)
+                // Publish this project's androidTest metadata so downstream consumers can enumerate
+                // it.
+                SimpleFileProducerTask.registerOrConfigure(
+                    project,
+                    name = "androidTestProjectMetadata",
+                    description =
+                      "Produces a metadata artifact indicating this project path produces an androidTest APK.",
+                    input = projectPath,
+                    group = "skippy",
+                  )
+                  .publishWith(skippyAndroidTestProjectPublisher)
+
+                // Fladle aggregates test APKs directly; emulator.wtf doesn't.
+                if (!foundryProperties.enableEmulatorWtfForAndroidTest) {
                   if (isLibraryVariant) {
                     variant.androidTest?.apply {
                       // Wire this up to the aggregator. No need for an intermediate task here.

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/artifacts/Resolver.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/artifacts/Resolver.kt
@@ -59,6 +59,9 @@ internal class Resolver<T : Serializable>(
 ) {
 
   internal companion object {
+    /** Name of the resolvable configuration for [declarableName], mirroring [internalName]. */
+    fun resolvableConfigurationName(declarableName: String): String = "${declarableName}Classpath"
+
     /**
      * Convenience function for creating a [Resolver] for inter-project resolving of
      * [FoundryArtifact].
@@ -97,7 +100,7 @@ internal class Resolver<T : Serializable>(
 
   // Following the naming pattern established by the Java Library plugin. See
   // https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
-  private val internalName = "${declarableName}Classpath"
+  private val internalName = resolvableConfigurationName(declarableName)
 
   /** Dependencies are declared on this configuration */
   val declarable: Configuration = project.configurations.dependencyScope(declarableName).get()


### PR DESCRIPTION
## Summary
Expose the set of androidTest-producing projects as a reusable public Foundry API, and publish the metadata that backs it unconditionally so any downstream consumer can enumerate those projects.

## Description

### Why
- Foundry knows which projects produce androidTest APKs, but there was no supported way for a build to obtain that set — consumers had to hand-maintain a list or run a task and read its output file.
- The backing `androidTestProjectMetadata` artifact was only published on the Fladle path.

### What Changed
- `StandardProjectConfigurations`: publish each affected project's `androidTestProjectMetadata` artifact unconditionally, instead of gating it behind `!enableEmulatorWtfForAndroidTest`. Only the Fladle APK-directory aggregation stays gated.
- `FoundryGradleUtil`: add `public fun Project.androidTestProjectPaths(): List<String>` — resolves the `SkippyAndroidTestProject` artifact view eagerly and reads each artifact's owning `ProjectComponentIdentifier` (project metadata, not file contents), so it is safe to call at configuration time and does not force the producer tasks to run. Fails fast with an actionable message if called before the root plugin's resolver exists.
- `Resolver`: extract `resolvableConfigurationName(declarableName)` so the accessor and the resolver share one configuration-name convention.

### Consumers
- Any build can now call `rootProject.androidTestProjectPaths()` to enumerate androidTest projects at configuration time.