### PR TITLE
Fix "androidTestImplementation dependencies are ignored"

### DIFF
--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/Configurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/Configurations.kt
@@ -37,6 +37,19 @@ internal object Configurations {
 
   fun isApi(name: String): Boolean = name.endsWith("api", ignoreCase = true)
 
+  /**
+   * Whether the androidTest configuration named [name] should be detached from its parent
+   * configurations (i.e. have its `extendsFrom` cleared).
+   *
+   * When a module hasn't opted into androidTest ([androidTestEnabled] is false), AGP disables the
+   * androidTest variant and builds nothing from its configurations. Those configurations still
+   * extend `implementation`/`api` though, so AGP reports every inherited dependency as ignored
+   * ("androidTestImplementation dependencies are ignored because androidTest is disabled").
+   * Detaching them leaves nothing to ignore. Opted-in modules keep the normal inheritance.
+   */
+  fun shouldDetachAndroidTestDependencies(name: String, androidTestEnabled: Boolean): Boolean =
+    isAndroidTest(name) && !androidTestEnabled
+
   object ErrorProne {
     const val ERROR_PRONE = "errorprone"
     const val ERROR_PRONE_JAVAC = "errorproneJavac"

--- a/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/main/kotlin/foundry/gradle/StandardProjectConfigurations.kt
@@ -784,6 +784,14 @@ internal class StandardProjectConfigurations(
             // compatible with Android SDK <26
             resolutionStrategy.force("org.objenesis:objenesis:$it")
           }
+
+          // Avoid AGP's "androidTest dependencies are ignored" warning when the variant is
+          // disabled. See Configurations.shouldDetachAndroidTestDependencies.
+          val androidTestEnabled =
+            foundryExtension.androidHandler.featuresHandler.androidTest.getOrElse(false)
+          if (Configurations.shouldDetachAndroidTestDependencies(name, androidTestEnabled)) {
+            setExtendsFrom(emptySet())
+          }
         }
       }
     }

--- a/platforms/gradle/foundry-gradle-plugin/src/test/kotlin/foundry/gradle/StandardProjectConfigurationsTest.kt
+++ b/platforms/gradle/foundry-gradle-plugin/src/test/kotlin/foundry/gradle/StandardProjectConfigurationsTest.kt
@@ -15,10 +15,31 @@
  */
 package foundry.gradle
 
+import com.google.common.truth.Truth.assertThat
 import foundry.gradle.Configurations.isPlatformConfigurationName
+import foundry.gradle.Configurations.shouldDetachAndroidTestDependencies
 import org.junit.Test
 
 class StandardProjectConfigurationsTest {
+
+  @Test
+  fun detachAndroidTestDependenciesWhenDisabled() {
+    // androidTest configs are detached only when the feature is not opted in, so AGP has no
+    // inherited dependencies to warn about on the disabled variant.
+    for (name in listOf("androidTestImplementation", "androidTestApi", "androidTestUtil")) {
+      assertThat(shouldDetachAndroidTestDependencies(name, androidTestEnabled = false)).isTrue()
+      assertThat(shouldDetachAndroidTestDependencies(name, androidTestEnabled = true)).isFalse()
+    }
+  }
+
+  @Test
+  fun neverDetachNonAndroidTestDependencies() {
+    // Unit test and main configs keep their inheritance regardless of the androidTest flag.
+    for (name in listOf("implementation", "api", "testImplementation", "testApi")) {
+      assertThat(shouldDetachAndroidTestDependencies(name, androidTestEnabled = false)).isFalse()
+      assertThat(shouldDetachAndroidTestDependencies(name, androidTestEnabled = true)).isFalse()
+    }
+  }
 
   @Test
   fun platformConfigurations() {


### PR DESCRIPTION
All of our modules are showing this warning when compiled:


```
WARNING: androidTestImplementation dependencies are ignored because androidTest is disabled.
Add android.sync.suppressAgpWarnings=GENERIC to the gradle.properties file to suppress this warning.
```

<!-- 

#### Testing

<img src="XXXCOPYURLXXX" alt="" width="300"/> 

<video src="XXXCOPYURLXXX" alt="" width="300"/>

| Before | After |
| ------------- | ------------- |
| <img src="XXXCOPYURLXXX" alt="" width="300"/> | <img src="XXXCOPYURLXXX" alt="" width="300"/> |


| Before | After |
| ------------- | ------------- |
| <video src="XXXCOPYURLXXX" alt="" width="300"/> | <video src="XXXCOPYURLXXX" alt="" width="300"/> |

<details>
  <summary>Detailed Section (click me)</summary>
  
</details>

-->

#### Ticket: [](https://jira.tinyspeck.com/browse/)

#### Feature flag(s): ``
